### PR TITLE
clarified no-compat option usage

### DIFF
--- a/docs/SSO.rst
+++ b/docs/SSO.rst
@@ -1737,9 +1737,9 @@ eXo Platform as SAML2 SP
    
    ::
    
-	$PLATFORM_SP/addon install exo-saml
+	$PLATFORM_SP/addon install exo-saml --no-compat
 
-.. note:: Add the option **--no-compat** for tomcat application server.
+.. note:: The **--no-compat** is mandatory due to a packaging glitch. Yet the add-on actually IS compatible with eXo Platform 5.2
 
 
 2.  After the installation of the SAML2 add-on, its 


### PR DESCRIPTION
the install command was confusing because it is nit complete. a note below tells to add no-compat option for Tomcat while To cat is the only app server supported in 5.2

I fixed the command and transformed the note to explain why no-compat is currently needed.