### PR TITLE
DOC-4356: Remove Jboss configurations on Installation chapter (#176)

### DIFF
--- a/docs/Administration_eXo_JCR.rst
+++ b/docs/Administration_eXo_JCR.rst
@@ -24,8 +24,7 @@ Administration
 
     -  :ref:`Performance tuning <chapter-Administration-PerformanceTuning>`
 
-       Instructions on JBoss AS tuning, JCR cache tuning, Clustering,
-       JVM parameters, and Force query hints.
+       Instructions on JCR cache tuning, Clustering, JVM parameters, and Force query hints.
 
 
 .. _chapter-Administration-Connectors:
@@ -45,9 +44,6 @@ Connectors
    Details of configuration parameters of FTP, such as command-port,
    data-min-port and data-max-port, system, and client-side-encoding.
 
--  :ref:`JCA resource adapter <JCR.JCA>`
-
-   Details of SessionFactory, configuration, and deployment.
 
 .. _JCR.WebDAV:
 
@@ -657,118 +653,6 @@ FTP includes the following configuration parameters:
    Define the character that will be used to replace the forbidden
    characters.
 
-.. _JCR.JCA:
-
-JCA resource adapter
-~~~~~~~~~~~~~~~~~~~~~
-
-.. note:: JCA is currently supported in eXo Platform JBoss bundle.
-
-JCR supports *J2EE Connector Architecture* 1.5, thus if you want to
-delegate the JCR Session lifecycle to your application server, you can
-use the JCA resource adapter for eXo JCR. This adapter only supports XA
-Transaction, in other words you cannot use it for local transactions.
-Since the JCR Sessions have not been designed to be shareable, the
-session pooling is simply not covered by the adapter.
-
-**SessionFactory**
-
-The equivalent of the ``javax.resource.cci.ConnectionFactory`` in JCA
-terminology is ``org.exoplatform.connectors.jcr.adapter.SessionFactory``
-in the context of eXo JCR. The resource that you will get thanks to a
-JNDI lookup is of the ``SessionFactory`` type and provides the following
-methods:
-
-.. code:: java
-
-       /**
-        * Get a JCR session corresponding to the repository
-        * defined in the configuration and the default workspace.
-        * @return a JCR session corresponding to the criteria
-        * @throws RepositoryException if the session could not be created
-        */
-       Session getSession() throws RepositoryException;
-
-       /**
-        * Get a JCR session corresponding to the repository
-        * defined in the configuration and the default workspace, using
-        * the given user name and password.
-        * @param userName the user name to use for the authentication
-        * @param password the password to use for the authentication
-        * @return a JCR session corresponding to the criteria
-        * @throws RepositoryException if the session could not be created
-        */
-       Session getSession(String userName, String password) throws RepositoryException;
-
-       /**
-        * Get a JCR session corresponding to the repository
-        * defined in the configuration and the given workspace.
-        * @param workspace the name of the expected workspace
-        * @return a JCR session corresponding to the criteria
-        * @throws RepositoryException if the session could not be created
-        */
-       Session getSession(String workspace) throws RepositoryException;
-
-       /**
-        * Get a JCR session corresponding to the repository
-        * defined in the configuration and the given workspace, using
-        * the given user name and password.
-        * @param workspace the name of the expected workspace
-        * @param userName the user name to use for the authentication
-        * @param password the password to use for the authentication
-        * @return a JCR session corresponding to the criteria
-        * @throws RepositoryException if the session could not be created
-        */
-       Session getSession(String workspace, String userName, String password) throws RepositoryException;
-
-**Configuration**
-
-+---------------------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
-| *PortalContainer*   | If no portal container can be found in the context of the request, the adapter will use the value of this parameter to get the name of the expected portal container to create the JCR sessions. This parameter is optional. By default, the default portal container will be used.   |
-+---------------------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
-| *Repository*        | The repository name used to create JCR sessions. This parameter is optional. By default, the current repository will be used.                                                                                                                                                         |
-+---------------------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
-
-
-**Deployment**
-
-Get/Download the JBoss bundle of eXo Platform 4 or higher.
-
-Go to the ``exo.jcr.connectors.jca`` folder, then run the
-``mvn clean install -Pplatform`` command.
-
-Deploy
-``exo.jcr.connectors.jca/target/exo.jcr.connectors.jca-1.15.x-GA.rar``
-in ``PLATFORM_JBOSS_HOME/standalone/deployments/``, then rename it to
-``exo-jcr.rar``.
-
-Configure the resource adapter in
-``PLATFORM_JBOSS_HOME/standalone/configuration/standalone-exo.xml`` by
-replacing:
-
-::
-
-    <subsystem xmlns="urn:jboss:domain:resource-adapters:1.1"/>
-
-with
-
-::
-
-    <subsystem xmlns="urn:jboss:domain:resource-adapters:1.1">
-        <resource-adapters>
-            <resource-adapter>
-                <archive>exo-jcr.rar</archive>
-                <transaction-support>XATransaction</transaction-support>
-                <connection-definitions>
-                    <connection-definition class-name="org.exoplatform.connectors.jcr.impl.adapter.ManagedSessionFactory"
-                    jndi-name="java:/jcr/Repository">
-                        <config-property name="PortalContainer">portal</config-property>
-                        <config-property name="Repository">repository</config-property>
-                    </connection-definition>
-                </connection-definitions>
-            </resource-adapter>
-        </resource-adapters>
-    </subsystem>
 
 .. _chapter-Administration-Database:
 

--- a/docs/Application.rst
+++ b/docs/Application.rst
@@ -182,26 +182,9 @@ Portlet deployment
 ~~~~~~~~~~~~~~~~~~~
 
 The portlet *war* file should be installed into
-``$PLATFORM_TOMCAT_HOME/webapps`` (in Tomcat) or
-``$PLATFORM_JBOSS_HOME/standalone/deployments`` (in JBoss).
+``$PLATFORM_TOMCAT_HOME/webapps``.
 
-**Particularly for JBoss**, you need to include a
-``WEB-INF/jboss-deployment-structure.xml`` file to your portlet *war*,
-to declare *platform.ear* as a dependency:
-
-.. code:: xml
-
-    <jboss-deployment-structure xmlns="urn:jboss:deployment-structure:1.2">
-        <deployment>
-            <dependencies>
-                <module name="deployment.platform.ear" export="true"/>
-            </dependencies>
-        </deployment>
-    </jboss-deployment-structure>
-
-For more information, see `Master Your Portlet Packaging in JBoss article, <http://blog.exoplatform.com/en/2014/04/22/master-portlet-packaging-jboss>`__.
-
-Both Tomcat and JBoss support hot deployment.
+eXo Platform server supports hot deployment.
 
 To test your portlet in action, you need to add it to a page. This task
 can be done in two ways:
@@ -462,7 +445,7 @@ every page.
 
 **Redeploying a portlet**
 
-Both Tomcat and JBoss support hot redeployment, so you can just replace
+eXo Platform server supports hot redeployment, so you can just replace
 the old war with the new one and it should work. However, depending on
 the technology the portlet uses, the hot redeployment might not work
 properly. In this case, a server restart is required.
@@ -1419,12 +1402,6 @@ The code sample can be found
 `here <https://github.com/exo-samples/docs-samples/tree/4.3.x/portlet/jsf2-portlet-cdi>`__.
 
 
-.. note:: Currently you could not use JSF together with CDI in Tomcat. This tutorial is for JBoss only.
-
-		  Also note that the deployment of this portlet does not follow :ref:`Portlet deployment <PLFDevGuide.DevelopingApplications.DevelopingPortlet.Deployment>`
-		  section completely, so do not miss the :ref:`deployment <PLFDevGuide.DevelopingApplications.DevelopingPortlet.JSF2_CDI.Deployment-in-JBoss>`
-		  part at the end of this tutorial.
-
 **So why CDI?**
 
 If you want to get a quick understanding about CDI, and current
@@ -1752,39 +1729,6 @@ For that, you will create two qualifiers, *Customer* and *Partner*.
 		  } 
 		}
     
-.. _PLFDevGuide.DevelopingApplications.DevelopingPortlet.JSF2_CDI.Deployment-in-JBoss:    
-
-**Deployment in eXo Platform JBoss**
-
-Your webapp needs to be scanned by Weld so you will not deploy it in
-``standalone/deployments`` as other portlet applications. Instead,
-deploy it into ``platform.ear`` and add a module in ``application.xml``.
-
-1. ``target/jsf2portlet-cdi-example.war`` into
-   ``$PLATFORM_JBOSS_HOME/standalone/deployments/platform.ear``.
-
-2. Edit ``$PLATFORM_JBOSS_HOME/standalone/deployments/platform.ear/META-INF/application.xml``
-   to add a module like the following. The module must be added before 
-   the **starter** module, so on top if you like that:
-
-   .. code:: xml
-
-		<module>
-			<web>
-				<web-uri>jsf2portlet-cdi-example.war</web-uri>
-				<context-root>jsf2portlet-cdi-example</context-root>
-			</web>
-		</module>
-
-   Then follow the :ref:`Portlet deployment <#PLFDevGuide.DevelopingApplications.DevelopingPortlet.Deployment>`
-   section to register and add the portlet to a page for testing.
-
-.. note:: Starting from eXo Platform 5.0, we upgraded to JBoss EAP 7.0 which uses `Contexts and Dependency Injection (CDI) 1.2 <https://access.redhat.com/documentation/en-us/red_hat_jboss_enterprise_application_platform/7.0/html/development_guide/contexts_and_dependency_injection_cdi#introduction_to_cdi>`__.
-		  CDI 1.2 comes with the new notion of implicit bean archive allowing
-		  to scan war archives for annotations to process by Weld (the JBoss
-		  implementation of CDI). This new feature has some conflicts with our
-		  development and thus it has been disabled by default for eXo Platform EAR
-		  including its addons.
 
 .. _PLFDevGuide.DevelopingApplications.DevelopingPortlet.PublicRenderParameter:
 
@@ -2260,8 +2204,7 @@ development:
 
 -  Juzu source code: https://github.com/juzu/juzu.
 
-This tutorial focuses on Juzu portlet deployment in PRODUCT Tomcat and
-JBoss.
+This tutorial focuses on Juzu portlet deployment in eXo Platform.
 
 The dependencies are different for each server and each dependency
 injection implementation, so the project will use different Maven build
@@ -2271,13 +2214,10 @@ profiles for packaging in each case:
    Tomcat using Guice.
 
 -  Use ``mvn clean package -Pplf-jboss-guice`` to build a package for
-   JBoss using Guice.
 
 -  Use ``mvn clean package -Pplf-tomcat-spring`` to build a package for
    Tomcat using Spring.
 
--  Use ``mvn clean package -Pplf-jboss-spring`` to build a package for
-   JBoss using Spring.
 
 .. note:: Currently, only Guice and Spring are covered in this tutorial. The
 		  other implementation, Weld, will be documented later.
@@ -2620,46 +2560,8 @@ Spring:
         <version>2.5.5</version>
     </dependency>
 
-Note that you can deploy this portlet using Guice in Tomcat and JBoss or
-using Spring in Tomcat as usual. However, to deploy this portlet using
-Spring in JBoss, the following dependencies are needed at runtime:
-
--  ``spring-beans-2.5.5.jar``
-
--  ``spring-context-2.5.5.jar``
-
--  ``spring-core-2.5.5.jar``
-
--  ``spring-web-2.5.5.jar``
-
-These dependencies have been already packaged in the generated
-``hellojz.war`` file. Therefore you can choose to deploy this portlet
-via the 2 following ways:
-
--  Copy these above dependencies from ``hellojz.war!/WEB-INF/lib/`` to
-   ``$PLATFORM_JBOSS_HOME/standalone/deployments/platform.ear!/lib``,
-   then deploy this portlet as usual.
-
--  Deploy the ``hellojz.war`` file into
-   ``$PLATFORM_JBOSS_HOME/standalone/deployments/platform.ear/`` and
-   include it as the first module in the
-   ``$PLATFORM_JBOSS_HOME/standalone/deployments/platform.ear/META-INF/application.xml``
-   file. The ``application.xml`` file will look like:
-
-   .. code:: xml
-
-       ...
-       <display-name>plf-enterprise-jbosseap-ear</display-name>
-       <initialize-in-order>true</initialize-in-order>
-       <!-- The first module -->
-       <module>
-       <web>
-         <web-uri>hellojz.war</web-uri>
-         <context-root>hello-portlet-sample</context-root>
-       </web>
-       </module>
-       <!-- Other modules -->
-       ...
+Note that you can deploy this portlet using Guice in Tomcat or
+using Spring in Tomcat as usual.
 
 .. _PLFDevGuide.DevelopingApplications.DevelopingPortlet.Spring.Intro:
 
@@ -2954,9 +2856,6 @@ requests to controllers.
 	   initialization of *DispatcherPortlet*. The goal is to define some
 	   beans at the application scope.
 
-.. note:: Pay attention to the attribute *version="2.5"*. The version 2.5 or
-		  greater is required. You should specify the version, otherwise it
-		  might not work in JBoss package.
 
 10. Edit ``applicationContext.xml``.
 
@@ -3184,9 +3083,7 @@ Here are the steps to create your first gadget:
 
 7. Install ``hello-gadget.war`` to:
 
-	-  ``$PLATFORM_TOMCAT_HOME/webapps/`` for Tomcat.
-
-	-  ``$PLATFORM_JBOSS_HOME/standalone/deployments/`` for JBoss.
+	-  ``$PLATFORM_TOMCAT_HOME/webapps/``.
 
 .. note:: See details about deployment in :ref:`portal extension section <PLFDevGuide.eXoAdd-ons.PortalExtension.Howto>`,
     especially if you use the traditional extension with jar to be backward compatible.
@@ -4170,10 +4067,7 @@ all source code of this tutorial
 8. Build and deploy the ``.jar`` file
    (``target/wiki-activity-type-1.0.jar``) into eXo Platform package.
 
-	-  ``$PLATFORM_TOMCAT_HOME/lib`` (in Tomcat)
-
-	-  ``$PLATFORM_JBOSS_HOME/standalone/deployments/platform.ear!/lib`` (in
-	   JBoss)
+	-  ``$PLATFORM_TOMCAT_HOME/lib``.
 
 **Testing**
 
@@ -5578,10 +5472,7 @@ component to the ``application/zip`` mimetype.
 
 7. Put this ``.jar`` file into the eXo Platform package.
 
-	-  ``$PLATFORM_TOMCAT_HOME/lib`` (in Tomcat).
-
-	-  ``$PLATFORM_JBOSS_HOME/standalone/deployments/platform.ear!/lib`` (in
-	   JBoss).
+	-  ``$PLATFORM_TOMCAT_HOME/lib``.
 
 8. Restart the server. The content of a ZIP file is now displayed as 
    below:

--- a/docs/Backup.rst
+++ b/docs/Backup.rst
@@ -78,9 +78,7 @@ Backup and Restore
 If you do not customize and configure eXo Platform, the whole data is located
 in one directory. So you just need to backup and restore the folder:
 
--  ``$PLATFORM_TOMCAT_HOME/gatein/data`` (in Tomcat).
-
--  ``$PLATFORM_JBOSS_HOME/standalone/data/gatein`` (in JBoss).
+-  ``$PLATFORM_TOMCAT_HOME/gatein/data``.
 
 .. note:: The above locations are the default ones, you may have different path to the data folder which is shared and accessible by your sever node(s).
 
@@ -93,7 +91,7 @@ restore file system data and DBMS tools to backup/restore SQL databases.
 The data folder contains these directories:
 
 -  ``exoplatform-es``: it contains data indexed by Elasticsearch when it
-   is in :ref:`embedded mode <#PLFAdminGuide.Elasticsearch.ES_Embedded>`.
+   is in :ref:`embedded mode <PLFAdminGuide.Elasticsearch.ES_Embedded>`.
 
 -  ``files``: it contains :ref:`file storage <Database.FileStorage>` 
    data.
@@ -113,13 +111,8 @@ The data folder contains these directories:
 File System Data
 ~~~~~~~~~~~~~~~~~
 
-You can check the data location in the customized configuration file:
-
--  In Tomcat, the file is ``$PLATFORM_TOMCAT_HOME/bin/setenv-customize``
-   (``.sh`` for Linux and ``.bat`` for Windows).
-
--  In JBoss, it is ``$PLATFORM_JBOSS_HOME/bin/standalone-customize``
-   (``.conf`` for Linux and ``.conf.bat`` for Windows).
+You can check the data location in the customized configuration file: ``$PLATFORM_TOMCAT_HOME/bin/setenv-customize``
+(``.sh`` for Linux and ``.bat`` for Windows).
 
 Open the file and find *EXO\_DATA\_DIR*. This variable indicates the
 folder you need to backup or restore. As explained above,

--- a/docs/Clustering.rst
+++ b/docs/Clustering.rst
@@ -131,17 +131,7 @@ Setting up eXo Platform cluster
 6. Configure ``exo.cluster.node.name`` property. Use a different name 
    for each node:
 
-   -  In JBoss, edit this property in the ``standalone-exo-cluster.xml``
-      file:
-
-      .. code:: xml
-
-            <system-properties>
-                <property name="exo.cluster.node.name" value="node1"/>
-            </system-properties>
-                           
-
-   -  In Tomcat, add the property in ``setenv-customize.sh`` (.bat for
+   -  Add the property in ``setenv-customize.sh`` (.bat for
       windows environments):
 
       -  For windows:
@@ -164,13 +154,8 @@ Setting up eXo Platform cluster
 8. Configure CometD Oort URL. Replace *localhost* in the following 
    examples with the IP or host name of the node.
 
-   -  In JBoss, edit ``standalone-exo-cluster.xml``:
 
-      .. code:: xml
-
-          <property name="exo.cometd.oort.url" value="http://localhost:8080/cometd/cometd"/>
-
-   -  In Tomcat, edit ``exo.properties``:
+   -  Edit ``exo.properties``:
 
       ::
 
@@ -188,14 +173,8 @@ Setting up eXo Platform cluster
    from the default port (``5577``). The situation is likely to happen 
    in a testing environment.
 
-   -  In JBoss, edit ``standalone-exo-cluster.xml`` file:
 
-      .. code:: xml
-
-          <!-- Configure the same port for all nodes in your cluster -->
-          <property name="exo.cometd.oort.multicast.groupPort" value="5579"/>
-
-   -  In Tomcat, edit ``exo.properties`` file:
+   -  Edit ``exo.properties`` file:
 
       ::
 
@@ -222,7 +201,7 @@ Setting up eXo Platform cluster
        node of this ``exo.properties`` is host1:port1, and that the 
        cluster is composed of three nodes : host1, host2 and host3.
 
-11. Only in Tomcat, configure the following:
+11. Configure the following:
 
     -  In ``setenv-customize.sh (.bat for Windows)``:
 
@@ -243,26 +222,10 @@ Setting up eXo Platform cluster
 12. Start the servers. **You must wait until node1 is fully started, 
     then start node2.**
 
-    In JBoss, you need to indicate the configuration file with -c option:
-    ``./bin/standalone.sh -b 0.0.0.0 -c standalone-exo-cluster.xml`` 
-    (.bat for Windows).
-
-    Only in JBoss, some other options that you can use in the start command:
-
-    -  **-Dexo.cluster.node.name=a-node-name** overrides the node name 
-       in the configuration file.
-
-    -  **-Djboss.socket.binding.port-offset=101**
-
-       This is useful in case you set up nodes in the same machine for
-       testing. You will not need to configure the port for every node. 
-       Just use a different port-offset in each start command.
 
 .. note:: If you run two nodes in the same machine for testing, change the default ports of node2 to avoid port conflict.
+		  Ports are configured in ``conf/server.xml``.
 
-		  In Tomcat, ports are configured in ``conf/server.xml``.
-
-		  In JBoss, use ``-Djboss.socket.binding.port-offset`` option mentioned above.
 
 To configure a front-end for your nodes, follow :ref:`Setting up Apache front-end <SetUpHttpFrontend.SetupApacheFrontend>`.
 
@@ -312,13 +275,7 @@ understanding:
    for details.
 
 For LOCAL INDEXING, the index directory should be a local path for each
-node. In JBoss it is set already by default:
-
-.. code:: xml
-
-    <property name="exo.jcr.index.data.dir" value="${exo.jcr.data.dir}/index"/>
-
-But for Tomcat, you need to set it yourself, in ``exo.properties`` file:
+node. You need to set it yourself, in ``exo.properties`` file:
 
 ::
 
@@ -328,14 +285,8 @@ If you want to use a SHARED INDEX for every node:
 
 Enable the profile *cluster-index-shared*.
 
--  In JBoss, edit
-   ``$PLATFORM_JBOSS_HOME/standalone/configuration/standalone-exo-cluster.xml``:
 
-   .. code:: xml
-
-       <property name="exo.profiles" value="all,cluster,cluster-index-shared"/>
-
--  In Tomcat, edit ``setenv-customize.sh`` (.bat for Windows, see
+-  Edit ``setenv-customize.sh`` (.bat for Windows, see
    :ref:`Customizing environment variables <CustomizingEnvironmentVariables>`):
 
    ::
@@ -345,14 +296,8 @@ Enable the profile *cluster-index-shared*.
 Set the index directory (``exo.jcr.index.data.dir``) to a network
 sharing path.
 
--  In JBoss, edit
-   ``$PLATFORM_JBOSS_HOME/standalone/configuration/standalone-exo-cluster.xml``:
 
-   .. code:: xml
-
-       <property name="exo.jcr.index.data.dir" value="${exo.shared.dir}/jcr/index"/>
-
--  In Tomcat, if you do not configure it, ``exo.jcr.index.data.dir`` is
+-  If you do not configure it, ``exo.jcr.index.data.dir`` is
    already set to a sub-folder of the shared directory ``EXO_DATA_DIR``.
    It is done in ``setenv.*``:
 
@@ -386,17 +331,8 @@ for the ``exo.properties`` file.
 To activate TCP default configuration files, enable the profile
 ``cluster-jgroups-tcp``:
 
--  In JBoss, edit ``standalone-exo-cluster.xml``:
 
-   .. code:: xml
-
-       <system-properties>
-           ...
-           <property name="exo.profiles" value="all,cluster,cluster-jgroups-tcp"/>
-           ...
-       </system-properties>
-
--  In Tomcat, edit ``setenv-customize.sh`` (.bat for Windows, see :ref:`Customizing environment variables <CustomizingEnvironmentVariables>`):
+-  Edit ``setenv-customize.sh`` (.bat for Windows, see :ref:`Customizing environment variables <CustomizingEnvironmentVariables>`):
 
    ::
 
@@ -1295,9 +1231,7 @@ Only when the variables are not enough, or when migrating from previous
 version you want to re-use your JGroups configuration files, you will
 follow this section to activate your xml files.
 
-1. Put your xml file somewhere, typically
-   ``standalone/configuration/gatein/jgroups/`` in JBoss and
-   ``gatein/conf/jgroups/`` in Tomcat.
+1. Put your xml file somewhere, typically ``gatein/conf/jgroups/``.
 
 2. Edit the following properties in ``exo.properties``:
 
@@ -1307,8 +1241,7 @@ follow this section to activate your xml files.
        exo.jcr.cluster.jgroups.config-url=file:${exo.jcr.cluster.jgroups.config}
        exo.idm.cluster.jgroups.config=${exo.conf.dir}/jgroups/jgroups-idm.xml
 
-In which ``exo.conf.dir`` is ``standalone/configuration/gatein`` in
-JBoss and ``gatein/conf`` in Tomcat by default.
+In which ``exo.conf.dir`` is ``gatein/conf`` by default.
 
 If you put your files somewhere else, pay attention that you must use an
 absolute path after "file:".

--- a/docs/Configuration.rst
+++ b/docs/Configuration.rst
@@ -194,12 +194,7 @@ simply do as follows:
 
 1. Create your own ``.properties`` file that must be named
    ``exo.properties``. This file contains all configurations to be
-   customized.
-
-   -  ``$PLATFORM_TOMCAT_HOME/gatein/conf/exo.properties`` (Tomcat).
-
-   -  ``$PLATFORM_JBOSS_HOME/standalone/configuration/gatein/exo.properties``
-   (JBoss).
+   customized: ``$PLATFORM_TOMCAT_HOME/gatein/conf/exo.properties``
 
 A ``.properties`` file has no header, so you do not need to preserve the
 header. You can refer to ``exo-sample.properties`` that is provided by
@@ -263,14 +258,10 @@ eXo Platform configuration
 
 In eXo Platform, almost all configurations are performed in a folder that is
 controlled by a system property named **exo.conf.dir**. This property is
-set by ``setenv.*`` scripts (Tomcat) or ``standalone-exo-*.xml`` files
-(JBoss).
+set by ``setenv.*`` scripts.
 
-The default value of **exo.conf.dir** is:
+The default value of **exo.conf.dir** is: ``$PLATFORM_TOMCAT_HOME/gatein/conf``.
 
--  ``$PLATFORM_TOMCAT_HOME/gatein/conf`` (Tomcat).
-
--  ``$PLATFORM_JBOSS_HOME/standalone/configuration/gatein`` (JBoss).
 
 That folder contains the following main files that you need to take
 care: ``exo.properties`` (if you need to override the eXo Platform
@@ -1722,8 +1713,7 @@ Typically, the JCR File System data consists of four folders:
 -  Swap data (temporary memory space).
 
 By default, these four folders are located under a common directory that
-is ``$PLATFORM_TOMCAT_HOME/gatein/data`` (Tomcat),
-``$PLATFORM_JBOSS_HOME/standalone/data/gatein`` (JBoss).
+is ``$PLATFORM_TOMCAT_HOME/gatein/data``.
 
 In production, it is recommended to configure it to use a directory
 separated from the package. Especially in cluster mode, it should be a
@@ -1741,24 +1731,6 @@ In Tomcat, the directory is configured by the environment variable
 You need to create the script file by copying/renaming the sample
 ``bin/setenv-customize.sample.(sh|bat)``. See :ref:`Customizing environment variables <CustomizingEnvironmentVariables>`
 for more information.
-
-**Configuration in Platform JBoss**
-
-In JBoss, the directory is configured by the system property
-``exo.data.dir``. Edit ``standalone/configuration/standalone-exo.xml``
-like below:
-
-.. code:: xml
-
-    <system-properties>
-        ...
-        <property name="exo.data.dir" value="/mnt/nfs/shared/exo/data"/>
-        ...
-    </system-properties>
-
-Note that if you are configuring the cluster mode, the configuration
-might be different. The file should be ``standalone-exo-cluster.xml``
-and the property should be ``exo.shared.dir``. See :ref:`Setting up eXo Platform cluster <Clustering.SettingUpCluster>`.
 
 .. _AssetsVersionConf:    
 
@@ -2471,10 +2443,7 @@ not stopped successfully when you shut down eXo Platform, and it causes
 problem in your next start.
 
 So `download <http://sourceforge.net/projects/sigar/files/>`__ the
-following files and install them to the lib folder
-(``$PLATFORM_TOMCAT_HOME/lib`` in Tomcat,
-``$PLATFORM_JBOSS_HOME/standalone/deployments/platform.ear/lib`` in
-JBoss:
+following files and install them to the lib folder :``$PLATFORM_TOMCAT_HOME/lib``
 
 -  ``sigar.jar``
 
@@ -2711,16 +2680,6 @@ Both sizes could be defined through these properties:
 
 .. note:: The size is in MB for all the above properties.
 
-.. warning:: If you are using eXo Platform in JBoss application server, note that in
-			 addition to the parameters described above aiming to customize files
-			 size, you should configure the value of the parameter
-			 ``max-post-size`` in ``standalone/configuration/standalone-exo.xml``
-			 which is set by default to 200 MB in eXo Platform package.
-
-			 .. code:: xml
-
-					<http-listener name="default" socket-binding="http" redirect-socket="https" max-post-size="209715200"/>
-
 .. tip:: For any others file upload location, the maximum file size is defined by the property ``exo.uploadLimit``.
 		 
 			 .. code::xml
@@ -2950,20 +2909,15 @@ By default, the logs are configured to:
 
 -  log errors and warnings on the console.
 
--  log ``$PLATFORM_TOMCAT_HOME/logs/platform.log`` (Tomcat), or
-   ``$PLATFORM_JBOSS_HOME/standalone/log/server.log`` (JBoss).
+-  log ``$PLATFORM_TOMCAT_HOME/logs/platform.log``.
 
 The logs are configured via the file:
 
--  ``$PLATFORM_TOMCAT_HOME/conf/logging.properties`` (Tomcat). Please
+-  ``$PLATFORM_TOMCAT_HOME/conf/logging.properties``. Please
    refer to `Tomcat's Logging
    Documentation <http://tomcat.apache.org/tomcat-7.0-doc/logging.html>`__
    for more information on how to adjust this file to your needs.
 
--  ``$PLATFORM_JBOSS_HOME/standalone/configuration/logging.properties``
-   (JBoss).
-   
-   
 .. _Configuration.JPA:
 
 =============================
@@ -3424,19 +3378,11 @@ The specific configuration of Portal caches can be found in the files:
 **i.** For **MOPSessionManager**, **NavigationService**,
 **DescriptionService**, **PageService**:
 
--  ``$PLATFORM_TOMCAT_HOME/webapps/portal.war!/WEB-INF/conf/portal/portal-configuration.xml``
-   (Tomcat).
-
--  ``$PLATFORM_JBOSS_HOME/standalone/deployments/platform.ear!/exo.portal.web.portal.war!/WEB-INF/conf/portal/portal-configuration.xml``
-   (JBoss).
+-  ``$PLATFORM_TOMCAT_HOME/webapps/portal.war!/WEB-INF/conf/portal/portal-configuration.xml``.
 
 **ii.** For **TemplateService** and **ResourceBundle**:
 
--  ``$PLATFORM_TOMCAT_HOME/webapps/platform-extension.war!/WEB-INF/conf/platform/cache-configuration.xml``
-   (Tomcat).
-
--  ``$PLATFORM_JBOSS_HOME/standalone/deployments/platform.ear!/platform-extension-webapp.war!/WEB-INF/conf/platform/cache-configuration.xml``
-   (JBoss).
+-  ``$PLATFORM_TOMCAT_HOME/webapps/platform-extension.war!/WEB-INF/conf/platform/cache-configuration.xml``.
 
 .. _Portal.MOPCache:
 
@@ -3620,11 +3566,7 @@ file.
 
 The specific configuration of **SettingCache** can be found in the file:
 
--  ``$PLATFORM_TOMCAT_HOME/lib/commons-component-common-X.Y.Z.jar!/conf/portal/configuration.xml``
-   (Tomcat).
-
--  ``$PLATFORM_JBOSS_HOME/standalone/deployments/platform.ear!/lib/commons-component-common.jar!/conf/portal/configuration.xml``
-   (JBoss).
+-  ``$PLATFORM_TOMCAT_HOME/lib/commons-component-common-X.Y.Z.jar!/conf/portal/configuration.xml``.
    
 .. _SettingCache:   
 
@@ -3749,18 +3691,11 @@ These properties are exposed via ``exo.properties`` for administrators.
 The full configuration can be found in XML configuration files. For SEO
 Cache, the file is:
 
--  ``$PLATFORM_TOMCAT_HOME/webapps/ecm-wcm-extension.war!/WEB-INF/conf/wcm-extension/wcm/seo-configuration.xml``
-   (Tomcat).
-
--  ``$PLATFORM_JBOSS_HOME/standalone/deployments/platform.ear!/ecms-packaging-wcm-webapp.war!/WEB-INF/conf/wcm-extension/wcm/seo-configuration.xml`` (JBoss).
+-  ``$PLATFORM_TOMCAT_HOME/webapps/ecm-wcm-extension.war!/WEB-INF/conf/wcm-extension/wcm/seo-configuration.xml``.
 
 For the other caches, the file is:
 
--  ``$PLATFORM_TOMCAT_HOME/webapps/ecm-wcm-core.war!/WEB-INF/conf/wcm-core/core-services-configuration.xml``
-   (Tomcat).
-
--  ``$PLATFORM_JBOSS_HOME/standalone/deployments/platform.ear!/ecms-core-webapp.war!/WEB-INF/conf/wcm-core/core-services-configuration.xml`` (JBoss).
-
+-  ``$PLATFORM_TOMCAT_HOME/webapps/ecm-wcm-core.war!/WEB-INF/conf/wcm-core/core-services-configuration.xml``.
 .. _ECMS.WCMDriveCache:
 
 Drive Cache
@@ -4031,11 +3966,8 @@ In particular:
 
 The specific configuration of each Social cache can be found in:
 
--  ``$PLATFORM_TOMCAT_HOME/webapps/social-extension.war!/WEB-INF/conf/social-extension/social/cache-configuration.xml``
-   (Tomcat).
+-  ``$PLATFORM_TOMCAT_HOME/webapps/social-extension.war!/WEB-INF/conf/social-extension/social/cache-configuration.xml``.
 
--  ``$PLATFORM_JBOSS_HOME/standalone/deployments/platform.ear/social-extension-war.war!/WEB-INF/conf/social-extension/social/cache-configuration.xml``
-   (JBoss).
 
 .. _Social.identityCache:
 
@@ -4319,11 +4251,8 @@ file.
 
 The specific configuration of each Forum cache can be found in:
 
--  ``$PLATFORM_TOMCAT_HOME/webapps/forum-extension.war!/WEB-INF/ks-extension/ks/forum/cache-configuration.xml``
-   (Tomcat).
+-  ``$PLATFORM_TOMCAT_HOME/webapps/forum-extension.war!/WEB-INF/ks-extension/ks/forum/cache-configuration.xml``.
 
--  ``$PLATFORM_JBOSS_HOME/standalone/deployments/platform.ear/forum-extension-webapp.war!/WEB-INF/ks-extension/ks/forum/cache-configuration.xml``
-   (JBoss).
 
 .. _Forum.userProfileCache:
 
@@ -4539,11 +4468,8 @@ In particular:
 
 The specific configuration of each Wiki cache can be found in:
 
--  ``$PLATFORM_TOMCAT_HOME/lib/wiki-service-xxx.jar!/conf/portal/cache-configuration.xml``
-   (Tomcat).
+-  ``$PLATFORM_TOMCAT_HOME/lib/wiki-service-xxx.jar!/conf/portal/cache-configuration.xml``.
 
--  ``$PLATFORM_JBOSS_HOME/standalone/deployments/platform.ear/lib/wiki-service.jar!/conf/portal/cache-configuration.xml``
-   (JBoss).
    
 .. _Wiki.RenderingCache:   
 
@@ -4678,11 +4604,7 @@ You can change values of these Calendar caches in
 
 The specific configuration of each Calendar cache can be found in:
 
--  ``$PLATFORM_TOMCAT_HOME/webapps/calendar-extension.war!/WEB-INF/cs-extension/cs/cs-configuration.xml``
-   (Tomcat).
-
--  ``$PLATFORM_JBOSS_HOME/standalone/deployments/platform.ear!/calendar-extension-webapp.war!/WEB-INF/cs-extension/cs/cs-configuration.xml``
-   (JBoss).
+-  ``$PLATFORM_TOMCAT_HOME/webapps/calendar-extension.war!/WEB-INF/cs-extension/cs/cs-configuration.xml``.
    
 .. _Calendar.groupCalendarCache:   
 
@@ -4896,11 +4818,7 @@ However, the word "membership" is sometimes used with the meaning of
 Next you will learn the configurations of predefined users, groups and
 memberships which are written in:
 
--  ``$PLATFORM_TOMCAT_HOME/webapps/platform-extension.war!/WEB-INF/conf/organization/organization-configuration.xml``
-   (Tomcat)
-
--  ``$PLATFORM_JBOSS_HOME/standalone/deployments/platform.ear!/platform-extension-webapp.war!/WEB-INF/conf/organization/organization-configuration.xml``
-   (JBoss)
+-  ``$PLATFORM_TOMCAT_HOME/webapps/platform-extension.war!/WEB-INF/conf/organization/organization-configuration.xml``.
 
 This section does not directly aim at changing those predefined
 organizational data, but if it is the further step you want to go, you
@@ -5019,11 +4937,8 @@ Gadget configuration
 ====================
 
 Gadget configuration consists of OAuth key, Shindig properties, and
-security token key. By default those configuration files are located at:
+security token key. By default those configuration files are located at ``gatein/conf/gadgets`.
 
--  ``gatein/conf/gadgets`` for Tomcat.
-
--  ``standalone/configuration/gatein/gadgets`` for JBoss.
 
 To use your customized configuration files, it is recommended that you
 replace default files in that location with yours.
@@ -5034,21 +4949,9 @@ besides gadgets, so take care that you have those files in the new
 folder. Also note that the folder of gadgets files will be
 ``${exo.conf.dir}/gadgets``.
 
-To change ``exo.conf.dir``:
+To change ``exo.conf.dir``, customize the variable ``EXO_CONF_DIR=/path/to/your/folder`` 
+(see :ref:`Customizing variables <CustomizingEnvironmentVariables>` for how-to).
 
--  In Tomcat: customize the variable
-   ``EXO_CONF_DIR=/path/to/your/folder`` (see :ref:`Customizing variables <CustomizingEnvironmentVariables>`
-   for how-to).
-
--  In JBoss: edit the property ``exo.conf.dir`` in
-   ``standalone/configuration/standalone-exo.xml``
-   (``standalone-exo-cluster.xml`` in cluster mode).
-
-   .. code:: xml
-
-       <sytem-properties>
-           <property name="exo.conf.dir" value="/path/to/your/folder"/>
-       </system-properties>
 
 The security token key (``key.txt``) is automatically generated by the
 server so you just need to acknowledge its location. Next is more
@@ -5743,9 +5646,7 @@ have not created this file, see :ref:`Configuration Overview <Configuration.Conf
 
 These configuration files are located in:
 
--  ``$PLATFORM_TOMCAT_HOME/gatein/conf/`` for Tomcat.
-
--  ``$PLATFORM_JBOSS_HOME/standalone/configuration/gatein/`` for JBoss.
+-  ``$PLATFORM_TOMCAT_HOME/gatein/conf/``.
 
 .. note:: You were asked to create the files for security during the setup. If
 			you include any parameter below into the ``exo.properties``, you

--- a/docs/Configuration_eXo_JCR.rst
+++ b/docs/Configuration_eXo_JCR.rst
@@ -4045,27 +4045,6 @@ below:
        </component>
      
 
-**A very specific TransactionService for JBoss AS**
-
-If you intend to use JBoss AS with Infinispan, you can use a very
-specific TransactionService for JBoss AS. See the configuration example
-as below:
-
-.. code:: xml
-
-        <component>
-          <key>org.exoplatform.services.transaction.TransactionService</key>
-          <type>org.exoplatform.services.transaction.impl.jboss.JBossTransactionService</type>
-          <!-- Uncomment the lines below if you want to set default transaction timeout that is expressed in seconds -->
-          <!--init-params>
-             <value-param>
-                <name>timeout</name>
-                <value>60</value>
-             </value-param>
-          </init-params-->
-       </component>
-     
-
 **TransactionsEssentials in standalone mode.**
 
 To use ``TransactionsEssentials``, simply add the following component

--- a/docs/Content.rst
+++ b/docs/Content.rst
@@ -816,13 +816,8 @@ code and file extension.
 6. Build the Maven project using the command: ``mvn clean install``.
 
 7. Put the ``.jar`` file (``target/custom-validator-1.0-SNAPSHOT.jar``)
-   into the ``lib`` folder of eXo Platform.
-
-   -  ``$PLATFORM_TOMCAT_HOME/lib`` (in Tomcat).
-
-   -  ``$PLATFORM_JBOSS_HOME/standalone/deployments/platform.ear!/lib`` (in
-      JBoss).
-
+   into the ``lib`` folder of eXo Platform: ``$PLATFORM_TOMCAT_HOME/lib``.
+   
 8. Start the eXo Platform server.
 
 **Testing**

--- a/docs/Deployment.rst
+++ b/docs/Deployment.rst
@@ -14,8 +14,7 @@ Deployment
        reverse-proxy front-end.
 
     -  :ref:`Configuring HTTP session timeout <Deployment.ConfiguringHTTPSessionTimeout>`
-       Instructions on how to configure the session timeout of the
-       Tomcat and Jboss servers.
+       Instructions on how to configure the session timeout of the platform.
 
 .. _Deployment.RemoveSampleApp:
 
@@ -34,8 +33,6 @@ First case - Your package is fresh so data is empty
 
 .. _First.Tomcat:
 
-In Tomcat:
-----------
 
 Remove the following files:
 
@@ -44,38 +41,6 @@ Remove the following files:
 -  ``$PLATFORM_TOMCAT_HOME/webapps/acme-intranet-portlet.war``
 
 -  ``$PLATFORM_TOMCAT_HOME/lib/platform-sample-acme-intranet-config-*.jar``
-
-.. _First.Jboss:
-
-In JBoss:
-----------
-
-1. Remove the following files:
-
-   -  ``$PLATFORM_JBOSS_HOME/standalone/deployments/platform.ear/platform-sample-acme-intranet-webapp.war``
-
-   -  ``$PLATFORM_JBOSS_HOME/standalone/deployments/platform.ear/platform-sample-acme-intranet-portlet.war``
-
-   -  ``$PLATFORM_JBOSS_HOME/standalone/deployments/platform.ear/lib/platform-sample-acme-intranet-config.jar``
-
-2. Open the
-   ``$PLATFORM_JBOSS_HOME/standalone/deployments/platform.ear/META-INF/application.xml``
-   file to comment out the following lines:
-
-	.. code:: xml
-
-		<module>
-		<web>
-		  <web-uri>platform-sample-acme-intranet-portlet.war</web-uri>
-		  <context-root>acme-intranet-portlet</context-root>
-		</web>
-		</module>
-		<module>
-		<web>
-		  <web-uri>platform-sample-acme-intranet-webapp.war</web-uri>
-		  <context-root>acme-intranet</context-root>
-		</web>
-		</module>
 		
 .. _RemoveSampleApp.Second:
 
@@ -89,15 +54,10 @@ To clean the data entirely, do the following steps:
 
 1. Stop the server if it is running.
 
-2. Remove the files (and change the configuration file for JBoss) as
-   described above.
+2. Remove the files as described above.
 
 3. Remove associated data. If you did not change the default data
-   configuration, just need to remove:
-
--  ``$PLATFORM_TOMCAT_HOME/gatein/data/`` (in Tomcat).
-
--  ``$PLATFORM_JBOSS_HOME/standalone/data/gatein/*`` (in JBoss).
+   configuration, just need to remove ``$PLATFORM_TOMCAT_HOME/gatein/data/``.
 
 4. Restart your server.
 

--- a/docs/Dev_eXo_Addons.rst
+++ b/docs/Dev_eXo_Addons.rst
@@ -321,29 +321,6 @@ Manager:
 
 2. Restart the server.
 
-.. _Jboss-deployment:
-
-**For JBoss:**
-
-1. Add new ``WEB-INF/jboss-deployment-structure.xml`` file to 
-   ``custom-extension.war`` with the following content:
-
-   .. code:: xml
-
-		<jboss-deployment-structure xmlns="urn:jboss:deployment-structure:1.2">
-			<deployment>
-				<dependencies>
-					<module name="deployment.platform.ear" export="true"/>
-				</dependencies>
-			</deployment>
-		</jboss-deployment-structure>
-
-2. Add ``custom-extension.war`` to
-   ``$PLATFORM_JBOSS_HOME/standalone/deployments/`` platform.ear 
-   directory.
-
-3. Restart the server.
-
 .. _AddonsManagerCompliance:
 
 Add-ons Manager compliance
@@ -355,37 +332,6 @@ different. The section :ref:`Packaging <PLFDevGuide.eXoAdd-ons.Packaging>`
 shows you how.
 
 The Add-ons Manager deploys the extension in the same way for Tomcat.
-For JBoss, it uses another method to deploy the .war. Here are the
-details:
-
--  The file ``jboss-deployment-structure.xml`` is not required.
-
--  The .war is deployed into
-   ``$PLATFORM_JBOSS_HOME/standalone/deployments/platform.ear``.
-
--  The Add-ons Manager will edit the
-   ``$PLATFORM_JBOSS_HOME/standalone/deployments/platform.ear/META-INF/application.xml``
-   to add a module as follows:
-
-   .. code:: xml
-
-       <application>
-           ...
-           <!-- Your custom-extension should be added before starter module. -->
-           <module>
-               <web>
-                   <web-uri>custom-extension.war</web-uri>
-                   <context-root>custom-extension</context-root>
-               </web>
-           </module>
-           ...
-           <module>
-               <web>
-                   <web-uri>exo.portal.starter.war.war</web-uri>
-                   <context-root>starter</context-root>
-               </web>
-           </module>
-       </application>
 
 .. _PLFDevGuide.eXoAdd-ons.PortalExtension.Examples:
 
@@ -539,13 +485,9 @@ need to compress JARs, WARs and other files into a zip archive:
 When installing an add-on, the Add-ons Manager copies files from the
 add-on archive into PRODUCT, as follows:
 
--  JARs: ``$PLATFORM_TOMCAT_HOME/lib/`` (Tomcat), or
-   ``$PLATFORM_JBOSS_HOME/standalone/deployments/platform.ear/lib/``
-   (JBoss).
+-  JARs: ``$PLATFORM_TOMCAT_HOME/lib/``.
 
--  WARs: ``$PLATFORM_TOMCAT_HOME/webapps/`` (Tomcat), or
-   ``$PLATFORM_JBOSS/HOME/standalone/deployments/platform.ear/``
-   (JBoss).
+-  WARs: ``$PLATFORM_TOMCAT_HOME/webapps/``.
 
 -  Other files and folders located at the root of the zip archive will
    be copied to the home directory of the PRODUCT server.
@@ -632,7 +574,7 @@ There are 2 ways to deploy an add-on:
 -  Use the Add-ons Manager - the standard way to install, uninstall, and
    update add-ons in eXo Platform. In this way, you will avoid the manual
    registration that might cause errors. The Add-on Manager allows you
-   to simplify your add-ons management in both Tomcat and JBoss EAP by
+   to simplify your add-ons management in eXo Platform server by
    copying all JARs and WARs in one step and uninstalling them without
    searching in the ``lib`` directory (more than 400 jars) and in the
    ``webapps`` directory (more than 50 wars).

--- a/docs/Developing_Rest_Service.rst
+++ b/docs/Developing_Rest_Service.rst
@@ -236,12 +236,7 @@ services are called ResourceContainers.
 
 5. Build the Maven project using the command: ``mvn clean install``.
 
-6. Put the ``.jar`` file into the eXo Platform package.
-
-	-  ``$PLATFORM_TOMCAT_HOME/lib`` (in Tomcat).
-
-	-  ``$PLATFORM_JBOSS_HOME/standalone/deployments/platform.ear!/lib`` 
-	   (in JBoss).
+6. Put the ``.jar`` file into the eXo Platform package: ``$PLATFORM_TOMCAT_HOME/lib``
 
 7. Restart the server, then open
    http://mycompany.com:8080/portal/rest/demo/listusers/0 in your browser.
@@ -328,8 +323,7 @@ The war custom-extension now looks like:
 
 3. Deploy your custom-extension into eXo Platform by putting
    ``custom-extension.war`` in the ``webapps`` folder and
-   ``custom-extension-config.jar`` in the ``lib`` folder. See :ref:`How to <PLFDevGuide.eXoAdd-ons.PortalExtension.Howto>` 
-   for both Tomcat and JBoss.
+   ``custom-extension-config.jar`` in the ``lib`` folder. See :ref:`How to <PLFDevGuide.eXoAdd-ons.PortalExtension.Howto>`.
 
 4. Start eXo Platform, then go to 
    http://mycompany.com:8080/portal/rest/groovyrest/helloworld/eXo. The

--- a/docs/GetStarted.rst
+++ b/docs/GetStarted.rst
@@ -733,8 +733,6 @@ using
 `JDWP <http://docs.oracle.com/javase/7/docs/technotes/guides/jpda/jdwp-spec.html>`__
 that enables debugging by Eclipse.
 
-**In Tomcat**
-
 In eXo Platform Tomcat, the Debug mode is turned on by appending ``--debug``
 to the startup command:
 
@@ -752,13 +750,6 @@ If you want to change the port (``address=8000``), you have to
 :ref:`customize environment variables <CustomizingEnvironmentVariables>`
 and edit the following variable: ``EXO_DEBUG_PORT="8000"``.
 
-**In JBoss**
-
-In eXo Platform JBoss, you should provide a port in the startup command:
-
-::
-
-	./bin/standalone.sh --debug 8787
 
 .. _PLFDevGuide.GettingStarted.DevMode:
 
@@ -768,9 +759,7 @@ Dev mode
 The Dev mode is useful for debugging container configuration, CSS and
 JavaScript.
 
-**In Tomcat**
-
-In eXo Platform Tomcat, the Dev mode is turned on by appending ``--dev`` 
+In eXo Platform, the Dev mode is turned on by appending ``--dev`` 
 to the startup command: 
 
 ::
@@ -783,11 +772,6 @@ This parameter will add the following system properties:
 
 -  **-Dexo.product.developing=true**
 
-**In JBoss**
-
-In eXo Platform JBoss, the ``--dev`` parameter is not supported. You need to
-:ref:`customize environment variables <CustomizingEnvironmentVariables>`
-to have the following variable: ``EXO_DEV=true``.
 
 **Effects of Dev mode**
 

--- a/docs/Installation.rst
+++ b/docs/Installation.rst
@@ -481,7 +481,7 @@ Installing eXo Platform Enterprise Edition
 ==========================================
 
 In this section, we will provide how to install the enterpise edition of
-eXo Platform in the two application servers: Tomcat and Jboss.
+eXo Platform in Tomcat application server.
 
 -  :ref:`Installing the Tomcat bundle <EnterpriseEdition.TomcatInstall>`
    Steps to install eXo Platform enterprise edition in Tomcat.
@@ -489,8 +489,6 @@ eXo Platform in the two application servers: Tomcat and Jboss.
 -  :ref:`Installing eXo Platform as a Windows service <EnterpriseEdition.TomcatInstallWinService>`
    Steps to install eXo Platform as a Windows service.
 
--  :ref:`Installing on JBoss EAP <EnterpriseEdition.JbossInstall>`
-   Steps to install eXo Platform enterprise edition in Jboss.
 
 .. _EnterpriseEdition.TomcatInstall:
 
@@ -576,11 +574,10 @@ adds two JVM options:
 
 -  **-Dexo.product.developing=true**
 
-    **Note**
 
-    The Debug and Dev modes are turned off by default and are not
-    recommended in production environment because of performance impact.
-    See more details in :ref:`Developer guide <#PLFDevGuide.GettingStarted.DebugAndDevMode>`.
+.. note:: The Debug and Dev modes are turned off by default and are not
+          recommended in production environment because of performance impact.
+          See more details in :ref:`Developer guide <#PLFDevGuide.GettingStarted.DebugAndDevMode>`.
 
 .. _EnterpriseEdition.TomcatInstallWinService:
 
@@ -672,98 +669,7 @@ The second way: Using the NSSM tool
        nssm stop <servicename>
 
    More details about NSSM commands in this `link <https://nssm.cc/usage>`__.
-
-.. _EnterpriseEdition.JbossInstall:
-
-Installing on JBoss EAP
-~~~~~~~~~~~~~~~~~~~~~~~~~
-
-Starting from the versions 5.1, eXo Platform integrates with JBoss EAP 7.1.
-
-Prerequisites
----------------
-
--  Have JBoss EAP 7.1 extracted in ``$PLATFORM_JBOSS_HOME``. You can
-   download and install JBoss EAP 7.1 by following instructions on this
-   `link <https://access.redhat.com/documentation/en-us/red_hat_jboss_enterprise_application_platform/7.1/html/installation_guide/installing_jboss_eap>`__.
-
--  Have the eXo Platform package for JBoss EAP downloaded into your local.
-
-Installing eXo Platform on JBoss EAP
---------------------------------------
-
-1. Extract your downloaded eXo Platform package.
-
-2. Copy all extracted folders and files into ``$PLATFORM_JBOSS_HOME``.
-
-.. note:: This step will overwrite some files of JBoss EAP with new files of eXo Platform.
-
-3. Optionally, if you want to customize the JVM Options, create a copy of
-   ``$PLATFORM_JBOSS_HOME/bin/standalone-customize.sample.conf`` on Linux
-   or ``$PLATFORM_JBOSS_HOME/bin/standalone-customize.sample.conf.bat`` on
-   Windows. Rename the copy to ``standalone-customize.conf`` (or
-   ``standalone-customize.conf.bat`` on Windows), then edit it with your
-   JVM Options.
-
-4. Start up the server.
-
--  On Linux and OS X:
-
-   ::
-
-       $PLATFORM_JBOSS_HOME/bin/standalone.sh
-
--  On Windows:
-
-   ::
-
-       %PLATFORM_JBOSS_HOME%\bin\standalone.bat
-
-The server starts up successfully when you see the following message in
-your log/console 
-
-	::
-
-		INFO  [org.jboss.as] (Controller Boot Thread) WFLYSRV0025: JBoss EAP 7.1.0.GA (WildFly Core 3.0.10.Final-redhat-1) started in 115316ms - Started 4570 of 4826 services (602 services are lazy, passive or on-demand)
-
-
-5. Shut down the server.
-
--  On Linux and OS X
-
-	::
-
-       $PLATFORM_JBOSS_HOME/bin/jboss-cli.sh --connect command=:shutdown
-                   
-
--  On Windows
-
-	::
-
-       %PLATFORM_JBOSS_HOME%\bin\jboss-cli.bat --connect command=:shutdown
-                   
-
-The server stops successfully when you see the following message in your
-log/console::
-
-    INFO  [org.jboss.as] (MSC service thread 1-4) WFLYSRV0050: JBoss EAP 7.1.0.GA (WildFly Core 3.0.10.Final-redhat-1) stopped in 13470ms
-
-
-.. note:: Since JBoss EAP 6.3, there is a new blocking timeout property for
-			JBoss startup.
-
-			This property is not a timeout per deployment but a timeout on
-			container stability and if ``jboss.as.management.blocking.timeout``
-			is reached during startup then all applications will be undeployed
-			and the container shutdown.
-	
-			The default value is set to 300s which is too low for eXo Platform in
-			which we overrode the value.
-
-			::
-
-				JAVA_OPTS="$JAVA_OPTS -Djboss.as.management.blocking.timeout=604800"
-				
+			
 				
 .. _TasksInstallation:	
 
@@ -1056,17 +962,6 @@ Their Windows versions are:
 
 Except their syntax, ``.sh`` and ``.bat`` versions are the same.
 
-In JBoss, the scripts are:
-
--  ``$PLATFORM_JBOSS_HOME/bin/standalone.conf`` - the default script.
-
--  ``$PLATFORM_JBOSS_HOME/bin/standalone-customize.conf`` - the
-   customized script.
-
--  ``$PLATFORM_JBOSS_HOME/bin/standalone.conf.bat`` - Windows version.
-
--  ``$PLATFORM_JBOSS_HOME/bin/standalone-customize.conf.bat`` - Windows
-   version.
 
 **Usage of the 2 scripts**
 
@@ -1088,12 +983,6 @@ In JBoss, the scripts are:
 
    -  For Tomcat in Windows: rename ``setenv-customize.sample.bat`` to
       ``setenv-customize.bat``.
-
-   -  For JBoss in Linux: rename ``standalone-customize.sample.conf`` to
-      ``standalone-customize.conf``.
-
-   -  For JBoss in Windows: rename ``standalone-customize.sample.conf.bat``
-      to ``standalone-customize.conf.bat``.
 
 2. Find the variable that you want to customize, uncomment it (by removing
    '#' in the ``.sh`` file or "REM" in the ``.bat`` file) and edit its
@@ -1258,24 +1147,6 @@ eXo Platform tries to ease it by exposing 3 variables that you can customize:
 |                                               | development tasks.          |
 +-----------------------------------------------+-----------------------------+
 
-**JBoss configuration**
-
-+-----------------------------------------------+-----------------------------+
-| Configuration                                 | Description                 |
-+===============================================+=============================+
-| ``MAX_FD="maximum"``                          | Specifies the maximum file  |
-|                                               | descriptor limit.           |
-+-----------------------------------------------+-----------------------------+
-| ``PROFILER=""``                               | Specifies a profiler        |
-|                                               | configuration file.         |
-+-----------------------------------------------+-----------------------------+
-| ``JAVA_OPTS="$JAVA_OPTS -Djboss.modules.lockl | Uncomment this to not use   |
-| ess=false"``                                  | JBoss Modules lockless      |
-|                                               | mode.                       |
-+-----------------------------------------------+-----------------------------+
-| ``JAVA_OPTS="$JAVA_OPTS -Djboss.modules.metri | Uncomment this to gather    |
-| cs=true"``                                    | JBoss Modules metrics.      |
-+-----------------------------------------------+-----------------------------+
 
 .. _AdvancedCustomization:
 
@@ -1352,10 +1223,6 @@ to the ``CATALINA_OPTS`` variable, for example:
 |                                               | and ssh port 2000.         |
 +-----------------------------------------------+----------------------------+
 
-For JBoss, similar variables can be customized by appending
-``JAVA_OPTS``, for example:
-
--  ``JAVA_OPTS="$JAVA_OPTS -Dcrash.telnet.port=12345 -Dcrash.ssh.port=54321"``
 
 .. _eXoProfiles:
 
@@ -1393,15 +1260,6 @@ variable is required:
 See :ref:`Customizing environment variables <CustomizingEnvironmentVariables>`
 to know how to customize the variables.
 
-To activate the ``minimal`` profile in **JBoss**, edit the property
-``exo.profiles`` in ``standalone/configuration/standalone-exo.xml``
-(``standalone-exo-cluster.xml`` in cluster mode):
-
-.. code:: xml
-
-    <system-properties>
-        <property name="exo.profiles" value="minimal"/>
-    </system-properties>
     
 .. _Troubleshooting:
 
@@ -1551,14 +1409,6 @@ You can use another port than 8080 as follows:
                   URIEncoding="UTF-8"
                   compression="off" compressionMinSize="2048"
                   noCompressionUserAgents=".*MSIE 6.*" compressableMimeType="text/html,text/xml,text/plain,text/css,text/javascript" />
-
--  In JBoss, edit the
-   ``$PLATFORM_JBOSS_HOME/standalone/configuration/standalone-exo.xml``
-   file and change 8080 into another port, at the following line:
-
-   .. code:: xml
-
-       <socket-binding name="http" port="8080"/>
 
 
 .. note:: In addition to the port 8080, eXo Platform may use some others, such as 8009, 8443. You always can manage those ports in the same way as above.

--- a/docs/LDAP.rst
+++ b/docs/LDAP.rst
@@ -212,8 +212,6 @@ that you can adapt by following the following sections.
 
 9. :ref:`Package and deploy <LDAP.QuickStart.PackagingDeploying>` your ldap-extension into Platform.
 
-.. note:: For JBoss, don’t forget to declare :ref:`deployment dependency <Jboss-deployment>`.
-
 10. Make sure the directory server is running, then start eXo Platform.
 
 .. _LDAP.QuickStart.PackagingDeploying:
@@ -221,11 +219,7 @@ that you can adapt by following the following sections.
 Packaging and deploying
 -------------------------
 
-The extension folder must be packaged into ``ldap-extension.war`` then copied to:
-
--  ``$PLATFORM_TOMCAT_HOME/webapps`` for Tomcat.
-
--  ``$PLATFORM_JBOSS_HOME/standalone/deployments`` for JBoss.
+The extension folder must be packaged into ``ldap-extension.war`` then copied to ``$PLATFORM_TOMCAT_HOME/webapps``.
 
 To compress the folder into a .war (and decompress the .war for editing), you can use any archiver tool that supports .war extension.
 You can use the JDK built-in tool **jar**, as follows:
@@ -244,8 +238,7 @@ You can use the JDK built-in tool **jar**, as follows:
 .. tip:: You should have ldap-extension packaged in .war when deploying it to production. However when testing, if you feel 
          uncomfortable having to edit a .war, you can skip compressing it. 
          In `Tomcat <https://tomcat.apache.org/tomcat-8.0-doc/deployer-howto.html>`__, just deploy the original 
-         folder *ldap-extension*. In `JBoss <https://access.redhat.com/documentation/en-us/red_hat_jboss_enterprise_application_platform/7.0/html/configuration_guide/deploying_applications>`__, 
-         rename it to ``ldap-extension.war``.
+         folder *ldap-extension*. 
 
 .. _LDAP.QuickStart.Testing:         
 

--- a/docs/Management.rst
+++ b/docs/Management.rst
@@ -105,14 +105,6 @@ section.
 After the start, put your JMX configurations in the form described in
 `Advanced Customization <AdvancedCustomization>` section.
 
-Although the two sections are written for Tomcat bundle, it is very
-similar for JBoss, except the customized configuration file. In JBoss,
-the file is ``$PLATFORM_JBOSS_HOME/bin/standalone-customize.conf`` for
-Linux, ``$PLATFORM_JBOSS_HOME/bin/standalone-customize.conf.bat`` for
-Windows. You can create it by using the sample file
-``$PLATFORM_JBOSS_HOME/bin/standalone-customize.sample.conf`` for Linux
-or ``$PLATFORM_JBOSS_HOME/bin/standalone-customize.sample.conf.bat`` for
-Windows.
 
 **Securing JMX connection**
 

--- a/docs/SSO.rst
+++ b/docs/SSO.rst
@@ -25,8 +25,6 @@ application.
 
     -  :ref:`SAML2 <eXoAddonsGuide.SSO.SAML2>`
 
-    -  :ref:`Single Sign-On in Cluster mode <eXoAddonsGuide.SSO.SSO_in_cluster>`
-
 .. _eXoAddonsGuide.SSO.CAS:
 
 ====================================
@@ -53,8 +51,7 @@ The integration between eXo Platform and CAS consists of 3 steps:
 
 -  **i.** CAS is deployed on Tomcat 7 server at **localhost:8888**.
 
--  **ii.** eXo Platform (Tomcat or JBoss EAP) is deployed at
-   **localhost:8080**.
+-  **ii.** eXo Platform is deployed at **localhost:8080**.
 
 .. _eXoAddonsGuide.SSO.CAS.CAS_server_setup:
 
@@ -216,16 +213,10 @@ to configure the eXo Platform server.
 eXo Platform server configuration
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-The eXo Platform server configuration is quite different between the Tomcat
-and JBoss packages. Here are instructions for both
-:ref:`Tomcat <eXoAddonsGuide.SSO.CAS.eXoPlatform_server_configuration.Tomcat>`
-and :ref:`JBoss <eXoAddonsGuide.SSO.CAS.eXoPlatform_server_configuration.JBoss>`
-bundles.
+In this section, we will detail how to configure eXo Platform server.
 
 .. _eXoAddonsGuide.SSO.CAS.eXoPlatform_server_configuration.Tomcat:
 
-In Tomcat
-----------
 
 Add the following to the
 ``$PLATFORM_TOMCAT_HOME/gatein/conf/exo.properties`` file (see
@@ -247,8 +238,7 @@ for this file):
 
 In previous versions of eXo Platform, there were much more changes needed in
 various configuration files. But now, all JARS are available in
-``$PLATFORM_TOMCAT_HOME/lib`` or
-``$PLATFORM_JBOSS_HOME/standalone/deployments/platform.ear/lib``, so you
+``$PLATFORM_TOMCAT_HOME/lib``, so you
 do not need to manually add any JAR files. If you are interested in
 technical details about the single properties and configuration, you can
 see the below.
@@ -266,10 +256,8 @@ see the below.
 -  ``gatein.sso.login.module.enabled`` &
    ``gatein.sso.login.module.class`` - There is a special login module
    configured for gatein-domain in
-   ``$PLATFORM_TOMCAT_HOME/conf/jaas.conf`` (Tomcat) or
-   ``$PLATFORM_JBOSS_HOME/standalone/configuration/standalone-exo.xml``
-   (JBoss) called **SSODelegateLoginModule**. If SSO is disabled, this
-   **SSODelegateLoginModule** is simply ignored during authentication
+   ``$PLATFORM_TOMCAT_HOME/conf/jaas.conf`` called **SSODelegateLoginModule**. 
+   If SSO is disabled, this **SSODelegateLoginModule** is simply ignored during authentication
    process. But if SSO is enabled by this property, it delegates the
    work to another login module configured via the next option
    ``gatein.sso.login.module.class``. **SSODelegateLoginModule** will
@@ -329,52 +317,6 @@ pages will redirect to the CAS centralized authentication form. And on
 CAS you will be able to authenticate with portal credentials (like
 john/gtn) thanks to Authentication plugin.
 
-.. _eXoAddonsGuide.SSO.CAS.eXoPlatform_server_configuration.JBoss:
-
-In JBoss
----------
-
-1. Edit the  file ``$PLATFORM_JBOSS_HOME/standalone/configuration/gatein/exo.properties``
-   (see :ref:`Configuration overview <Configuration.ConfigurationOverview>` for this file):
-
-   ::
-
-		# SSO
-				gatein.sso.enabled=true
-				gatein.sso.callback.enabled=${gatein.sso.enabled}
-				gatein.sso.login.module.enabled=${gatein.sso.enabled}
-				gatein.sso.login.module.class=org.gatein.sso.agent.login.SSOLoginModule
-				gatein.sso.server.url=http://localhost:8888/cas
-				gatein.sso.portal.url=http://localhost:8080
-				gatein.sso.filter.logout.class=org.gatein.sso.agent.filter.CASLogoutFilter
-				gatein.sso.filter.logout.url=${gatein.sso.server.url}/logout
-				gatein.sso.filter.login.sso.url=${gatein.sso.server.url}/login?service=${gatein.sso.portal.url}/@@portal.container.name@@/initiatessologin
-
-   In which:
-
-   -  **gatein.sso.server.url** (= http://localhost:8888/cas in this
-      example) is the URL of your CAS web context.
-
-   -  **gatein.sso.portal.url** (= http://localhost:8080 in this example)
-      is the URL of your eXo Platform server.
-
-2. Uncomment the below login module in ``$PLATFORM_JBOSS_HOME/standalone/configuration/standalone-exo.xml``,
-   then change ``${gatein.sso.login.module.enabled}`` and
-   ``${gatein.sso.login.module.class}`` into
-   ``#{gatein.sso.login.module.enabled}`` and
-   ``#{gatein.sso.login.module.class}`` respectively.
-
-   .. code:: xml
-
-		<login-module code="org.gatein.sso.integration.SSODelegateLoginModule" flag="required">
-			<module-option name="enabled" value="#{gatein.sso.login.module.enabled}"/>
-			<module-option name="delegateClassName" value="#{gatein.sso.login.module.class}"/>
-			<module-option name="portalContainerName" value="portal"/>
-			<module-option name="realmName" value="gatein-domain"/>
-			<module-option name="password-stacking" value="useFirstPass"/>
-		</login-module>
-
-Now, you can move to the next section for :ref:`testing <eXoAddonsGuide.SSO.CAS.Testing>`.
 
 .. _eXoAddonsGuide.SSO.CAS.Testing:
 
@@ -499,8 +441,7 @@ The integration between eXo Platform and OpenAM consists of 2 steps:
 
 -  **i.** OpenAM is deployed on Tomcat at **localhost:8888**.
 
--  **ii.** eXo Platform (Tomcat or JBoss) is deployed at
-   **localhost:8080**.
+-  **ii.** eXo Platform is deployed at **localhost:8080**.
 
 .. _eXoAddonsGuide.SSO.OpenAM.OpenAM_server_setup:
 
@@ -768,15 +709,11 @@ to configure the eXo Platform server.
 eXo Platform server configuration
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Here are instructions for both
-:ref:`Tomcat <eXoAddonsGuide.SSO.OpenAM.eXoPlatform_server_configuration.Tomcat>`
-and :ref:`JBoss <eXoAddonsGuide.SSO.OpenAM.eXoPlatform_server_configuration.JBoss>`
-packages.
+Here are instructions for 
+:ref:`eXo Platform server <eXoAddonsGuide.SSO.OpenAM.eXoPlatform_server_configuration.Tomcat>`
 
 .. _eXoAddonsGuide.SSO.OpenAM.eXoPlatform_server_configuration.Tomcat:
 
-In Tomcat
-----------
 
 Add the following to the
 ``$PLATFORM_TOMCAT_HOME/gatein/conf/exo.properties`` file to have the
@@ -808,62 +745,6 @@ In which:
 -  **gatein.sso.openam.realm** (= **exo** in this example) is the realm
    created in previous steps.
 
-.. _eXoAddonsGuide.SSO.OpenAM.eXoPlatform_server_configuration.JBoss:
-
-In JBoss
----------
-
-
-1. Edit the
-   ``$PLATFORM_JBOSS_HOME/standalone/configuration/gatein/exo.properties``
-   file to have the following lines (see :ref:`Configuration
-   overview <#PLFAdminGuide.Configuration.ConfigurationOverview>` for
-   this file):
-
-   ::
-
-		# SSO
-		gatein.sso.enabled=true
-		gatein.sso.callback.enabled=${gatein.sso.enabled}
-		gatein.sso.login.module.enabled=${gatein.sso.enabled}
-		gatein.sso.login.module.class=org.gatein.sso.agent.login.SSOLoginModule
-		gatein.sso.server.url=http://localhost:8888/openam
-		gatein.sso.openam.realm=exo
-		gatein.sso.portal.url=http://localhost:8080
-		gatein.sso.filter.logout.class=org.gatein.sso.agent.filter.OpenSSOLogoutFilter
-		gatein.sso.filter.logout.url=${gatein.sso.server.url}/UI/Logout
-		gatein.sso.filter.login.sso.url=${gatein.sso.server.url}/UI/Login?realm=${gatein.sso.openam.realm}&goto=${gatein.sso.portal.url}/@@portal.container.name@@/initiatessologin
-
-In which:
-
--  ``gatein.sso.server.url`` (= http://localhost:8888/openam in this
-   example) is the URL of your OpenAM web context.
-
--  ``gatein.sso.portal.url`` (= http://localhost:8080 in this example)
-   is the URL of your eXo Platform server.
-
--  ``gatein.sso.openam.realm`` (= **gatein** in this example) is the
-   realm created in previous steps.
-
-2. Uncomment the below login module in
-   ``$PLATFORM_JBOSS_HOME/standalone/configuration/standalone-exo.xml``,
-   then change ``${gatein.sso.login.module.enabled}`` and
-   ``${gatein.sso.login.module.class}`` into
-   ``#{gatein.sso.login.module.enabled}`` and
-   ``#{gatein.sso.login.module.class}`` respectively.
-
-   .. code:: xml
-
-		<login-module code="org.gatein.sso.integration.SSODelegateLoginModule" flag="required">
-			<module-option name="enabled" value="#{gatein.sso.login.module.enabled}"/>
-			<module-option name="delegateClassName" value="#{gatein.sso.login.module.class}"/>
-			<module-option name="portalContainerName" value="portal"/>
-			<module-option name="realmName" value="gatein-domain"/>
-			<module-option name="password-stacking" value="useFirstPass"/>
-		</login-module>
-
-After configuring the eXo Platform server, move to the :ref:`next section <eXoAddonsGuide.SSO.OpenAM.Testing>` 
-for testing.
 
 .. _eXoAddonsGuide.SSO.OpenAM.Testing:
 
@@ -896,7 +777,7 @@ for for more details.
 Cross-domain authentication configuration
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-In the above example (in both JBoss and Tomcat), the eXo Platform and SSO
+In the above example, the eXo Platform and SSO
 servers are deployed at **localhost:8080** and **localhost:8888**. The
 above configuration works if both servers are deployed on the same
 machine or the same domain, like eXo Platform on **portal.mydomain.com** and
@@ -908,10 +789,8 @@ eXo Platform on **portal.yourdomain.com:8080** and OpenAM on
 both sides, as follows:
 
 1. On portal side, change the configuration that you have done to
-   ``$PLATFORM_TOMCAT_HOME/gatein/conf/exo.properties`` (Tomcat), or
-   ``$PLATFORM_JBOSS_HOME/standalone/configuration/gatein/exo.properties``
-   (JBoss) to have the following lines (see :ref:`Configuration overview <Configuration.ConfigurationOverview>` 
-   for this file):
+   ``$PLATFORM_TOMCAT_HOME/gatein/conf/exo.properties`` to have the following lines 
+   (see :ref:`Configuration overview <Configuration.ConfigurationOverview>` for this file):
 
    ::
 
@@ -1412,87 +1291,6 @@ Go to ``$PLATFORM_HOME``, and install SPNEGO add-on with the command:
 
 5. Start eXo Platform.
 
-**Intergating SPNEGO with eXo Platform JBoss**
-
-1. Add the login module "spnego-server" as the child of the
-   ``<security-domains>`` section of the
-   ``$PLATFORM_JBOSS_HOME/standalone/configuration/standalone-exo.xml``
-   file.
-
-   .. code:: xml
-
-		<security-domain name="spnego-server" cache-type="default">
-				<authentication>
-					<login-module code="com.sun.security.auth.module.Krb5LoginModule" flag="required">
-						<module-option name="storeKey" value="true"/>
-						<module-option name="doNotPrompt" value="true"/>
-						<module-option name="useKeyTab" value="true"/>
-						<module-option name="keyTab" value="/etc/krb5.keytab"/>
-						<module-option name="principal" value="HTTP/server.example.com@EXAMPLE.COM"/>
-						<module-option name="useFirstPass" value="true"/>
-						<module-option name="debug" value="true"/>
-						<module-option name="isInitiator" value="false"/>
-					</login-module>
-				</authentication>
-			</security-domain>
-
-.. note:: On Windows environment, you should change the path of keytab. For
-          example, if this file is put into the D drive, it should be:
-          keyTab="D:/server.keytab".
-
-2. Uncomment the below login module in ``standalone-exo.xml``, then change
-   ``${gatein.sso.login.module.enabled}`` and
-   ``${gatein.sso.login.module.class}`` into
-   ``#{gatein.sso.login.module.enabled}`` and
-   ``#{gatein.sso.login.module.class}`` respectively.
-
-   .. code:: xml
-
-		<login-module code="org.gatein.sso.integration.SSODelegateLoginModule" flag="required">
-				<module-option name="enabled" value="#{gatein.sso.login.module.enabled}"/>
-				<module-option name="delegateClassName" value="#{gatein.sso.login.module.class}"/>
-				<module-option name="portalContainerName" value="portal"/>
-				<module-option name="realmName" value="gatein-domain"/>
-				<module-option name="password-stacking" value="useFirstPass"/>
-			</login-module>
-
-3. Configure SSO for eXo Platform by appending these configurations into
-   the ``$PLATFORM_JBOSS_HOME/standalone/configuration/gatein/exo.properties``
-   file (see :ref:`Configuration overview <PLFAdminGuide.Configuration.ConfigurationOverview>` 
-   for this file).
-
-   .. code:: xml
-
-		# SSO
-			gatein.sso.enabled=true
-			gatein.sso.filter.spnego.enabled=true
-			gatein.sso.callback.enabled=false
-			gatein.sso.skip.jsp.redirection=false
-			gatein.sso.login.module.enabled=true
-			gatein.sso.login.module.class=org.gatein.security.sso.spnego.SPNEGOSSOLoginModule
-			gatein.sso.filter.login.sso.url=/@@portal.container.name@@/spnegosso
-			gatein.sso.filter.initiatelogin.enabled=false
-			gatein.sso.valve.enabled=false
-			gatein.sso.filter.logout.enabled=false
-
-4. Start eXo Platform by using the command:
-
-   - On linux:
-
-     ::
-     
-			./standalone.sh -Djava.security.krb5.realm=EXAMPLE.COM -Djava.security.krb5.kdc=$AD_MACHINE_NAME.example.com -b server.example.com
-   
-   - On Windows:
-       
-     ::
-
-			standalone.bat -Djava.security.krb5.realm=EXAMPLE.COM -Djava.security.krb5.kdc=$AD_MACHINE_NAME.example.com -b server.example.com
-
-.. note:: ``$AD_MACHINE_NAME`` is name of the machine that has Active Directory installed.
-
-Next, move to the final step to :ref:`configure the client <eXoAddonsGuide.SSO.SPNEGO.Client_Configuration>` 
-(browser you are using).
 
 .. _eXoAddonsGuide.SSO.SPNEGO.Client_Configuration:
 
@@ -1649,29 +1447,6 @@ form. In this case, you will need to add the
            };
        ...
 
--  ``$PLATFORM_JBOSS_HOME/standalone/configuration/standalone-exo.xml``
-   (in JBoss). The ``standalone-exo.xml`` now looks like.
-
-   .. code:: xml
-
-       ...
-           <security-domain name="gatein-domain" cache-type="default">
-               <authentication>
-                   <login-module code="org.gatein.sso.integration.SSODelegateLoginModule" flag="required">
-                       <module-option name="enabled" value="#{gatein.sso.login.module.enabled}" />
-                       <module-option name="delegateClassName" value="#{gatein.sso.login.module.class}" />
-                       <module-option name="portalContainerName" value="portal" />
-                       <module-option name="enableFormAuthentication" value="false"/>
-                       <module-option name="realmName" value="gatein-domain" />
-                       <module-option name="password-stacking" value="useFirstPass" />
-                   </login-module>
-                   <login-module code="org.exoplatform.services.security.j2ee.JBossAS7LoginModule" flag="required">
-                       <module-option name="portalContainerName" value="portal"/>
-                       <module-option name="realmName" value="gatein-domain"/>
-                   </login-module>
-               </authentication>
-           </security-domain>
-       ...
 
 .. _eXoAddonsGuide.SSO.SAML2:
 
@@ -1961,8 +1736,7 @@ follows:
    Remember them to use in next steps.
 
 2. Install your file to
-   ``PLATFORM_*/standalone/configuration/gatein/saml2/`` (for Jboss) or
-   ``PLATFORM_*/gatein/conf/saml2/`` (for Tomcat) if you are configuring
+   ``PLATFORM_*/gatein/conf/saml2/`` if you are configuring
    eXo Platform SP/IDP. Install it to ``WEB-INF/classes/`` inside
    ``PLATFORM_*/standalone/deployments/idp-sig.war`` if you are configuring
    ``idp-sig.war``.
@@ -1970,13 +1744,9 @@ follows:
 3. Modify picketlink configuration file to provide your **keystore
    password** and a **key password**. The picketlink configuration file is:
 
-   -  ``PLATFORM_SP/standalone/configuration/gatein/saml2/picketlink-sp.xml``
-      (for Jboss) and ``PLATFORM_SP/gatein/conf/saml2/picketlink-sp.xml``
-      (for Tomcat) if you are configuring eXo Platform SP.
+   -  ``PLATFORM_SP/gatein/conf/saml2/picketlink-sp.xml`` if you are configuring eXo Platform SP.
 
-   -  ``PLATFORM_IDP/standalone/configuration/gatein/saml2/picketlink-idp.xml``
-      (for Jboss) and ``PLATFORM_IDP/gatein/conf/saml2/picketlink-sp.xml``
-      (for Tomcat) if you are configuring eXo Platform IDP.
+   -  ``PLATFORM_IDP/gatein/conf/saml2/picketlink-sp.xml``if you are configuring eXo Platform IDP.
 
    -  ``WEB-INF/picketlink.xml`` inside
       ``PLATFORM_*/standalone/deployments/idp-sig.war`` if you are
@@ -1996,161 +1766,6 @@ The following configuration is for SP, similar for IDP and
     </KeyProvider>
 
 .. note:: On Windows, you should use the absolute link to the keystore file, instead of using ``${gatein.sso.picketlink.keystore}``.
-
-.. _eXoAddonsGuide.SSO.SSO_in_cluster:
-
-==============================
-Single Sign-On in Cluster mode
-==============================
-
-.. note:: Currently this content is for eXo Platform JBoss only.
-
-In the cluster mode, the eXo Platform SSO valve can be used to
-authenticate a user on one eXo Platform node and have that
-authentication automatically carried across to other nodes in the
-cluster.
-
-Clustered SSO with Load Balancer
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-If you are running the cluster mode with Apache Load Balancer, you are
-using the same URL to access the servers (which is actually URL of the
-Load Balancer). You need to enable SSO by modifying the
-``$PLATFORM_JBOSS_HOME/standalone/configuration/standalone-exo-cluster.xml``
-file, as follows:
-
--  Find **subsystem** that has **xmlns="urn:jboss:domain:web:1.4"**. It
-   looks like:
-
-   .. code:: xml
-
-       <subsystem xmlns="urn:jboss:domain:web:1.4" default-virtual-server="default-host" native="false">
-           <connector name="http" protocol="HTTP/1.1" scheme="http" socket-binding="http"/>
-           <connector name="ajp" protocol="AJP/1.3" scheme="http" socket-binding="ajp"/>
-           <virtual-server name="default-host" enable-welcome-root="true">
-               <alias name="localhost"/>
-               <alias name="example.com"/>
-           </virtual-server>
-       </subsystem>
-
--  Add **<sso cache-container="web" cache-name="sso"
-   reauthenticate="false" />** right after **<alias
-   name="example.com"/>**. This will be:
-
-   .. code:: xml
-
-       <subsystem xmlns="urn:jboss:domain:web:1.4" default-virtual-server="default-host" native="false">
-           <connector name="http" protocol="HTTP/1.1" scheme="http" socket-binding="http"/>
-           <connector name="ajp" protocol="AJP/1.3" scheme="http" socket-binding="ajp"/>
-           <virtual-server name="default-host" enable-welcome-root="true">
-               <alias name="localhost"/>
-               <alias name="example.com"/>
-               <sso cache-container="web" cache-name="sso" reauthenticate="false" />
-           </virtual-server>
-       </subsystem>
-
-Clustered SSO in a Shared DNS Domain
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-If you are accessing the servers through different URLs in the same DNS
-domain, Single Sign-On can be configured by adding the domain parameter
-to the SSO configuration entry.
-
-Let's see what is the difference. In case Load Balancer is used
-(described above):
-
-.. code:: xml
-
-    <sso cache-container="web" cache-name="sso" reauthenticate="false" />
-
-In this case:
-
-.. code:: xml
-
-    <sso cache-container="web" cache-name="sso" reauthenticate="false" domain="yourdomain.com"/>
-
-The parameter must be added to the entry on all servers in the cluster
-and the name of the shared DNS domain must be specified as its value.
-This configuration ensures that the **JSESSIONIDSSO** cookie will be
-scoped to the specified domain, which is otherwise scoped only to the
-host where the initial authentication was performed.
-
-The following example demonstrates how to simulate and test this case on
-a Linux machine. There are 2 nodes in the cluster.
-
-Configuring and testing SSO in a shared DNS Domain
-----------------------------------------------------
-
-1. Add the following lines to the ``/etc/hosts`` file:
-
-   ::
-
-		127.0.1.1 machine1.yourdomain.com
-		127.0.1.2 machine2.yourdomain.com
-
-2. On both servers, modify the
-   ``$PLATFORM_JBOSS_HOME/standalone/configuration/standalone-exo-cluster.xml``
-   file to have:
-
-	.. code:: xml
-
-		<subsystem xmlns="urn:jboss:domain:web:1.4" default-virtual-server="default-host" native="false">
-			<connector name="http" protocol="HTTP/1.1" scheme="http" socket-binding="http"/>
-			<connector name="ajp" protocol="AJP/1.3" scheme="http" socket-binding="ajp"/>
-			<virtual-server name="default-host" enable-welcome-root="true">
-				<alias name="localhost"/>
-				<alias name="example.com"/>
-				<sso cache-container="web" cache-name="sso" reauthenticate="false" domain="yourdomain.com"/>
-			</virtual-server>
-		</subsystem>
-
-3. Start the first server using the following command:
-
-   ::
-
-		./standalone.sh -b machine1.yourdomain.com -c standalone-exo-cluster.xml -Djboss.node.name=node1
-
-4. Start the second server using:
-
-   ::
-
-		./standalone.sh -b machine2.yourdomain.com -c standalone-exo-cluster.xml -Djboss.node.name=node2
-
-5. Access the first server at http://machine1.yourdomain.com:8080/portal
-   and sign in.
-
-6. Access the second server at http://machine2.yourdomain.com:8080/portal
-   and test that you are automatically signed in.
-
-7. Sign out from one server and test that you are automatically signed 
-   out from the other one.
-
-Re-authentication
-~~~~~~~~~~~~~~~~~~~
-
-The eXo Platform SSO valve can also be used to authenticate with any
-other web application. If that application uses the same roles as the
-main eXo Platform instance, no further configuration is required.
-Because the eXo Platform SSO valve includes the same JAAS principal in
-all HTTP requests, even in requests to other web applications, matching
-roles ensure successful authentication with those applications.
-
-To enable the single sing-on authentication with an application that
-uses different roles, you need to set the ``reauthenticate`` parameter
-of the ``sso`` eXo Platform Web subsystem configuration entry to
-``true``:
-
-.. code:: xml
-
-    <sso cache-container="web" cache-name="sso" reauthenticate="true" />
-
-The ``true`` value ensures that reauthentication with user credentials
-will be performed against the web application's security domain in each
-HTTP request. This will enforce creation of a new principal with updated
-roles for the web application. As user credentials are used for
-authentication in this case, it is required that the same user
-credentials exist in both the web application and the JBoss Portal
-Platform instance.
 
 
 

--- a/docs/Security.rst
+++ b/docs/Security.rst
@@ -64,8 +64,7 @@ entry declares a Realm name and at least one login module. Each login
 module consists of a Java class and some parameters which are specified 
 by the class.
 
-Below is the default Realm in the Tomcat bundle. In JBoss, it looks
-different but basically, the explanation is right for both.
+Below is the default Realm in the Tomcat bundle.
 
 ::
 
@@ -112,41 +111,6 @@ Declaring JAAS Realm in eXo Platform
 -  A "security domain" property in
    ``$PLATFORM_TOMCAT_HOME/gatein/conf/exo.properties`` (about this
    file, see :ref:`Configuration overview <Configuration.ConfigurationOverview>`)
-   needs to be set equal to the Realm name:
-
-   ::
-
-       exo.security.domain=gatein-domain
-
-**In the JBoss package**
-
--  The default Realm is declared in the
-   ``$PLATFORM_JBOSS_HOME/standalone/configuration/standalone-exo.xml``
-   file, at the following lines:
-
-   .. code:: xml
-
-       <security-domain name="gatein-domain" cache-type="default">
-           <authentication>
-               <!--
-               <login-module code="org.gatein.sso.integration.SSODelegateLoginModule" flag="required">
-                   <module-option name="enabled" value="${gatein.sso.login.module.enabled}"/>
-                   <module-option name="delegateClassName" value="${gatein.sso.login.module.class}"/>
-                   <module-option name="portalContainerName" value="portal"/>
-                   <module-option name="realmName" value="gatein-domain"/>
-                   <module-option name="password-stacking" value="useFirstPass"/>
-               </login-module>
-               -->
-               <login-module code="org.exoplatform.services.security.j2ee.JBossAS7LoginModule" flag="required">
-                   <module-option name="portalContainerName" value="portal"/>
-                   <module-option name="realmName" value="gatein-domain"/>
-               </login-module>
-           </authentication>
-       </security-domain>
-
--  A "security domain" property in
-   ``$PLATFORM_JBOSS_HOME/standalone/configuration/gatein/exo.properties``
-   (about this file, see :ref:`Configuration overview <Configuration.ConfigurationOverview>`)
    needs to be set equal to the Realm name:
 
    ::
@@ -205,25 +169,6 @@ re-configure:
 
 .. note:: The ``.war`` files are located under the ``$PLATFORM_TOMCAT_HOME/webapps`` folder.
 
-**In the JBoss package:**
-
--  ``exo.portal.web.portal.war``: ``/WEB-INF/jboss-web.xml``,
-   ``/WEB-INF/web.xml``, ``/META-INF/context.xml``.
-
--  ``exo.portal.web.rest.war``: ``/WEB-INF/jboss-web.xml``,
-   ``/WEB-INF/web.xml``.
-
--  ``calendar-extension-webapp.war``: ``/WEB-INF/jboss-web.xml``.
-
--  ``forum-extension-webapp.war``: ``/WEB-INF/jboss-web.xml``.
-
--  ``wiki-extension-webapp.war``: ``/WEB-INF/jboss-web.xml``.
-
--  ``ecms-core-webapp.war``: ``/WEB-INF/jboss-web.xml``.
-
--  ``ecms-packaging-wcm-webapp.war``: ``/WEB-INF/jboss-web.xml``.
-
-.. note:: The ``.war`` files are located under the ``$PLATFORM_JBOSS_HOME/standalone/deployments/platform.ear`` folder.
 
 .. _Security.GadgetProxyConfig:
 
@@ -248,10 +193,7 @@ gadget server is installed.
 To specify domains that you want to allow or deny, modify the file:
 
 -  ``$PLATFORM_TOMCAT_HOME/webapps/portal.war/WEB-INF/conf/common/common-configuration.xml``
-   (in Tomcat).
 
--  ``$PLATFORM_JBOSS_HOME/standalone/deployments/platform.ear/exo.portal.web.portal.war/WEB-INF/conf/common/common-configuration.xml``
-   (in JBoss).
 
 The default configuration is:
 
@@ -485,13 +427,11 @@ post <http://blog.exoplatform.com/en/2014/04/17/apache-2-nginx-highly-secure-pfs
 Configuring the HTTP connector
 -------------------------------
 
-In both eXo Platform Tomcat and JBoss distributions, there is a default HTTP
-(8080) connector.
+In eXo Platform distribution, there is a default HTTP (8080) connector.
 
 In any case, you should configure that connector so that eXo Platform is
 aware of the proxy in front of it.
 
--  **In Tomcat**
 
 Set the following property in
 ``$PLATFORM_TOMCAT_HOME/gatein/conf/exo.properties`` file:
@@ -514,30 +454,6 @@ this:
       noCompressionUserAgents=".*MSIE 6.*" compressableMimeType="text/html,text/xml,text/plain,text/css,text/javascript"
       proxyName="proxy1.com" proxyPort="443" scheme="https" />
 
--  **In JBoss**
-
-1. Set the following property in
-   ``$PLATFORM_JBOSS_HOME/standalone/configuration/gatein/exo.properties``
-   file:
-
-   ::
-
-		exo.base.url=https://proxy1.com
-
-2. In ``$PLATFORM_JBOSS_HOME/standalone/configuration/standalone-exo.xml``,
-   add the property proxy-address-forwarding="true" in the configuration of
-   http-listener:
-
-   .. code:: xml
-
-			<http-listener name="default" redirect-socket="https" 
-						socket-binding="http" max-post-size="209715200" 
-						proxy-address-forwarding="true"/>
-
-After restarting the proxy and eXo Platform, you can test
-*https://proxy1.com*. If you are testing with dummy server names, make
-sure you created the hosts "proxy1.com" and "exo1.com" in the file
-``/etc/hosts``.
 
 .. _PLFAdminGuide.Security.HTTPSConf.eXo:
 
@@ -589,25 +505,6 @@ After starting eXo Platform, you can connect to
 *https://exo1.com:8443/portal*. If you are testing with dummy server
 names, make sure you created the host "exo1.com" in the file
 ``/etc/hosts``.
-
-Configuring eXo Platform's JBoss
-----------------------------------
-
-To configure JBoss to run under HTTPS, you just need to set the
-following property in
-``$PLATFORM_JBOSS_HOME/standalone/configuration/gatein/exo.properties``
-file:
-
-::
-
-    exo.base.url=https://exo1.com:8443
-
-After starting JBoss, you can connect to eXo Platform at
-*https://exo1.com:8443/portal*. If you are testing with dummy server
-names, make sure you created the host "exo1.com" in the file
-``/etc/hosts``.
-
-
 
 .. _Security.KeyRemembermeToken:
 
@@ -675,8 +572,7 @@ example). The valid value of algorithms and other parameters can be
 found
 `here <http://docs.oracle.com/javase/6/docs/technotes/guides/security/StandardNames.html#SecretKeyFactor>`__.
 
-Then, place the generated file under ``gatein/conf/codec`` (in Tomcat)
-or ``standalone/configuration/gatein/codec`` (in JBoss).
+Then, place the generated file under ``gatein/conf/codec``.
 
 2. Update the ``jca-symmetric-codec.properties`` file with the 
    parameters used in your keytool command:
@@ -701,10 +597,8 @@ Updating password encryption key
 
 The password encryption uses a keystore file. By default, the file is:
 
--  ``$PLATFORM_TOMCAT_HOME/gatein/conf/codec/codeckey.txt`` (in Tomcat).
+-  ``$PLATFORM_TOMCAT_HOME/gatein/conf/codec/codeckey.txt``
 
--  ``$PLATFORM_JBOSS_HOME/standalone/configuration/gatein/codec/codeckey.txt``
-   (in JBoss).
 
 To update the password encryption key, just remove the file, then
 restart the server. The keystore file will be re-created at the startup

--- a/docs/Upgrade.rst
+++ b/docs/Upgrade.rst
@@ -51,21 +51,6 @@ In this section, we will present all the breaking changes you should
 know before starting the upgrade to 5.2 version.
 
 
-**JBoss EAP upgrade**
-
-JBoss EAP 7.1 version is used in eXo Platform 5.1.
-
-This version comes with a bunch of improvements, including the use of 
-the new security framework WildFly Elytron and the support of HTTP/2.
-More information on this new version are available at 
-`https://www.redhat.com/en/blog/red-hat-releases-jboss-eap-71 <https://www.redhat.com/en/blog/red-hat-releases-jboss-eap-71>`__.
-
-
-You can find
-`here <https://access.redhat.com/documentation/en-us/red_hat_jboss_enterprise_application_platform/7.1/html-single/migration_guide/index>`__,
-a full documentation about the upgrade to JBoss EAP 7.1.
-
-
 **Templates changes**
 
 Some Groovy templates have been changed in eXo Platform 5.2, check
@@ -220,10 +205,6 @@ Before the upgrade, you need to:
 			-  Find out if you need to adjust anything to make your upgrade faster and more efficient.
 
 
-.. tip:: JBoss EAP was upgraded to 7.1 version to benefit from its last updates and improvements.
-		 You can check changelogs `for JBOSS <https://access.redhat.com/documentation/en-us/red_hat_jboss_enterprise_application_platform/7.1/html/7.1.0_release_notes/index>`__.
-
-
 .. _Upgrade.Process:
 
 ===============
@@ -249,16 +230,13 @@ procedure.
 
 **Upgrade to a new eXo Platform version**
 
-**For Tomcat and JBoss packages**
 
 1. Stop the old version of eXo Platform, in this case the 5.1 version.
 
 2. Apply your customizations into eXo Platform 5.2.
 
    -  If you have changed the configuration properties via
-      ``$PLATFORM_TOMCAT_HOME/gatein/conf/exo.properties`` (Tomcat) or
-      ``$PLATFORM_JBOSS_HOME/standalone/configuration/gatein/exo.properties``
-      (JBoss), you can update them to the same file in the new eXo 
+      ``$PLATFORM_TOMCAT_HOME/gatein/conf/exo.properties`` you can update them to the same file in the new eXo 
       Platform version.
 
    -  If you use a populated organizational data source (such as LDAP),
@@ -299,9 +277,7 @@ Here are good ways you can follow during and after upgrading:
 
 -  Monitor the server console/log file to be aware of the upgrade status
    or any issues during the upgrade. By default, eXo Platform records all
-   information in ``$PLATFORM_TOMCAT_HOME/logs/platform.log`` (in
-   Tomcat), ``$PLATFORM_JBOSS_HOME/standalone/log/server.log`` (in
-   JBoss).
+   information in ``$PLATFORM_TOMCAT_HOME/logs/platform.log``.
 
    A successful upgrade typically logs the followings:
 

--- a/docs/database_configuration.rst
+++ b/docs/database_configuration.rst
@@ -102,8 +102,7 @@ Configuring eXo Platform
 			 could be used for testing purpose but it is not possible to use it
 			 in production environments.
 
-eXo Platform relies on the application server (Tomcat/JBoss) to access
-databases. It uses three JNDI datasources:
+eXo Platform relies on the Tomcat application server to access databases. It uses three JNDI datasources:
 
 -  IDM uses *exo-idm\_portal*.
 
@@ -117,12 +116,10 @@ credentials.
 
 .. _ConfigureDBTomcat:
 
-For Tomcat
-~~~~~~~~~~~
 
 1. Configure the datasources.
 
-   -  i. Edit ``conf/server.xml`` to remove the default HSQL configuration:
+   i. Edit ``conf/server.xml`` to remove the default HSQL configuration:
 
       .. code:: xml
 
@@ -136,7 +133,7 @@ For Tomcat
           <Resource name="exo-jpa_portal" ...
           username="sa" password="" driverClassName="org.hsqldb.jdbcDriver" .../>
 
-   -  ii. Add a new one. For MySQL as an example, you will just need to
+   ii. Add a new one. For MySQL as an example, you will just need to
       copy the sample in ``conf/server-mysql.xml``:
 
       .. code:: xml
@@ -154,13 +151,13 @@ For Tomcat
 				...
 				username="plf" password="plf" driverClassName="com.mysql.jdbc.Driver" url="jdbc:mysql://localhost:3306/plf?autoReconnect=true&amp;characterEncoding=utf8" />
 
-   -  iii. Edit username, password, url (host, port and database name).
-      Besides MySQL, if you are using Enterprise Edition, you will find the
-      samples for other RDBMSs in ``conf/server-*.xml``.
+   iii. Edit username, password, url (host, port and database name).
+        Besides MySQL, if you are using Enterprise Edition, you will find the
+        samples for other RDBMSs in ``conf/server-*.xml``.
 
-   -  iv. Append this character encoding to the url in case your 
-      database character set is ``utf8``. For example, in MySQL (this 
-      is different between RDBMSs):
+   iv. Append this character encoding to the url in case your 
+       database character set is ``utf8``. For example, in MySQL (this 
+       is different between RDBMSs):
 
       .. code:: xml
 
@@ -204,187 +201,6 @@ If you have not created ``exo.properties`` yet, see :ref:`Configuration overview
 		 your database vendor website. For example, for MySQL:
 		 http://dev.mysql.com/downloads/connector/j/, and for Oracle:
 		 http://www.oracle.com/technetwork/database/features/jdbc/index-091264.html.
-
-.. _ConfigureDBJboss:
-
-For JBoss
-~~~~~~~~~~~
-
-1. Configure the datasources.
-
-   -  i. Edit ``standalone/configuration/standalone-exo.xml`` to remove the
-      default HSQL configuration:
-
-      .. code:: xml
-
-				  <!-- eXo IDM Datasource for PLF -->
-				   <datasource enabled="true" jndi-name="java:/comp/env/exo-idm_portal" jta="false" pool-name="exo-idm_portal" spy="false" use-ccm="true" use-java-context="true">
-				   <!-- HSQLDB -->
-				     <driver>hsqldb-driver.jar</driver>
-				     <driver-class>org.hsqldb.jdbcDriver</driver-class>
-				     <connection-url>jdbc:hsqldb:file:${exo.data.dir}/hsql/exo-plf;shutdown=true;hsqldb.write_delay=false;hsqldb.tx=mvcc;</connection-url>
-				     ...
-				  <!-- eXo JCR Datasource for PLF -->
-				   <datasource enabled="true" jndi-name="java:/comp/env/exo-jcr_portal" jta="false" pool-name="exo-jcr_portal" spy="false" use-ccm="true" use-java-context="true">
-				   <!-- HSQLDB -->
-					   <driver>hsqldb-driver.jar</driver>
-					   <driver-class>org.hsqldb.jdbcDriver</driver-class>
-					   <connection-url>jdbc:hsqldb:file:${exo.data.dir}/hsql/exo-plf;shutdown=true;hsqldb.write_delay=false;hsqldb.tx=mvcc;</connection-url>
-					    ...
-				  <!-- eXo JPA Datasource for PLF -->
-				   <datasource enabled="true" jndi-name="java:/comp/env/exo-jpa_portal" jta="false" pool-name="exo-jpa_portal" spy="false" use-ccm="true" use-java-context="true">
-				   <!-- HSQLDB -->
-				    <driver>hsqldb-driver.jar</driver>
-				    <driver-class>org.hsqldb.jdbcDriver</driver-class>
-				    <connection-url>jdbc:hsqldb:file:${exo.data.dir}/hsql/exo-plf;shutdown=true;hsqldb.write_delay=false;hsqldb.tx=mvcc;</connection-url>
-				     ...
-
-   -  ii. For MySQL as an example, need to uncomment some lines in the
-      file, edit driver, username, password, url:
-
-      .. code:: xml
-
-		   <!-- MySQL -->
-		   <driver>mysql-connector-java-5.1.44.jar_com.mysql.jdbc.Driver_5_1</driver>
-		   <driver-class>com.mysql.jdbc.Driver</driver-class>
-		   <connection-url>jdbc:mysql://localhost:3306/plf?autoReconnect=true</connection-url>
-		   ...
-		   <security>
-			   <user-name>root</username>
-			   <password>exoplf</password>
-		   </security>
-		   <validation>
-			   ...
-			   <!-- MySQL -->
-			   <exception-sorter class-name="org.jboss.jca.adapters.jdbc.extensions.mysql.MySQLExceptionSorter" />
-			   <valid-connection-checker class-name="org.jboss.jca.adapters.jdbc.extensions.mysql.MySQLValidConnectionChecker" />
-
-.. note:: The recommended version of MySQL JDBC driver for eXo Platfom 
-          5.0 is **5.1.44**. This driver version has two JDBC driver
-          implementations **com.mysql.jdbc.Driver** and
-          **com.mysql.fabric.jdbc.FabricMySQLDriver**, so Jboss deploys
-          them as ``mysql-connector-java-5.1.44.jar_com.mysql.jdbc.Driver_5_1`` 
-          and ``mysql-connector-java-5.1.44.jar_com.mysql.fabric.jdbc.FabricMySQLDriver_5_1``.
-          Therefore the ``driver`` parameter must be set to
-          **mysql-connector-java-5.1.44.jar\_com.mysql.jdbc.Driver\_5\_1**,
-          as in the above example.
-          
-          
-
-  -  iii. Append this character encoding to the url in case your database
-     character set is ``utf8``. For example, in MySQL (this is different
-     between RDBMSs):
-
-      .. code:: xml
-
-           <connection-url>jdbc:mysql://localhost:3306/plf?autoReconnect=true&amp;characterEncoding=utf8</connection-url>
-
-2. Set the SQL Dialect if necessary.
-
-   This step is not mandatory because the dialect is auto-detected in most
-   cases. You only need to take care of it for some particular RDBMSs:
-
-   -  i. For JCR, only when you are using MySQL and database character set
-      ``utf8``, you need to edit
-      ``standalone/configuration/gatein/exo.properties`` file to have:
-
-      ::
-
-          exo.jcr.datasource.dialect=MySQL-UTF8
-
-   -  ii. For IDM, eXo Platform detects automatically the dialect for
-      RDBMSs listed
-      `here <http://docs.jboss.org/hibernate/orm/4.1/manual/en-US/html_single/#configuration-optional-dialects>`__.
-      Only when your RDBMS is **not** in the list, for example *Postgres
-      Plus Advanced Server 9.2*, you will need to edit
-      ``standalone/configuration/gatein/exo.properties`` file to have:
-
-      ::
-
-          hibernate.dialect=org.hibernate.dialect.PostgresPlusDialect
-
-If you have not created ``exo.properties`` yet, see :ref:`Configuration overview <Configuration.ConfigurationOverview>`.
-
-3. Download the JDBC driver for Java and install it to ``$PLATFORM_JBOSS_HOME/standalone/deployments``.
-
-.. tip:: Normally you can find out an appropriate driver for your JDK from
-         your database vendor website. For example, for MySQL:
-         http://dev.mysql.com/downloads/connector/j/, and for Oracle:
-         http://www.oracle.com/technetwork/database/features/jdbc/index-091264.html.
-
-.. note:: Particularly to MySQL, this fast install method might not work for
-		  some couples of MySQL server and driver versions. If it happens to
-		  you, solve it by installing the driver as a *module*. See details
-		  below.
-
-**Installing JDBC driver as a JBoss module**
-
-This alternative method is applied to solve a deployment problem with
-some couples of MySQL server and driver versions. There is no statement
-that indicates exactly the versions, but the problem likely happens with
-some most recent versions, such as MySQL server 5.6.19 and
-mysql-connector-java-5.1.35-bin.jar.
-
--  When it happens, you will get a JBAS014775 message like the
-   following, and Platform JBoss does not start successfully ::
-
-       JBAS014775:    New missing/unsatisfied dependencies:
-             service jboss.jdbc-driver.mysql-connector-java-5_1_35-bin_jar (missing) dependents: 
-             [service jboss.data-source.java:/comp/env/exo-idm_portal, 
-             service jboss.driver-demander.java:/comp/env/exo-jcr_portal, 
-             service jboss.driver-demander.java:/comp/env/exo-idm_portal, JBAS014799: ... and 3 more ]
-
-Then you should remove the jar from
-``$PLATFORM_JBOSS_HOME/standalone/deployments/`` and install it to JBoss
-modules as follows:
-
-1. Create a new folder: ``$PLATFORM_JBOSS_HOME/modules/com/mysql/main/``.
-
-2. Place the driver (.jar) in the created folder.
-
-3. Create a ``module.xml`` file in the created folder, with the following
-   content:
-
-	.. code:: xml
-
-		<?xml version="1.0" encoding="UTF-8"?>
-		<module xmlns="urn:jboss:module:1.0" name="com.mysql">  
-			<resources>  
-				<resource-root path="mysql-connector-java-5.1.35-bin.jar"/>  <!--replace this with your jar file-->
-			</resources>  
-			<dependencies>  
-				<module name="javax.api"/>
-			</dependencies>  
-		</module>
-
-4. Modify the datasources configuration in ``standalone-exo.xml`` to
-   declare a driver in *drivers* tag and reference to it in *datasource*
-   tag:
-
-	.. code:: xml
-
-		<subsystem xmlns="urn:jboss:domain:datasources:1.1">
-			<datasources>
-				<!-- eXo IDM Datasource for PLF -->
-				<datasource enabled="true" jndi-name="java:/comp/env/exo-idm_portal" jta="false" pool-name="exo-idm_portal" spy="false" use-ccm="true" use-java-context="true">
-
-					<driver>com.mysql</driver>
-					<connection-url>jdbc:mysql://localhost:3306/plf?autoReconnect=true</connection-url>
-
-					<!-- note: don't put driver-class tag here-->
-					...
-				</datasource>
-				<!-- similar to other datasources, JCR (and Quartz in cluster) -->
-
-				<drivers>
-					<driver name="com.mysql" module="com.mysql">
-						<xa-datasource-class>com.mysql.jdbc.jdbc2.optional.MysqlXADataSource</xa-datasource-class>
-						<driver-class>com.mysql.jdbc.Driver</driver-class>
-					</driver>
-				</drivers>
-			</datasources>
-		</subsystem>
-
 
 .. _Database.DockerDatabase:
 
@@ -483,11 +299,9 @@ you need to edit the following properties:
     # name of the datasource that will be used by eXo JCR
     exo.jcr.datasource.name=java:/comp/env/exo-jcr
 
-in ``gatein/conf/exo.properties`` (Tomcat), or
-``standalone/configuration/gatein/exo.properties`` (JBoss).
+in ``gatein/conf/exo.properties``
 
-If you have not created ``exo.properties`` yet, see `Configuration
-overview <#PLFAdminGuide.Configuration.ConfigurationOverview>`__.
+If you have not created ``exo.properties`` yet, see `Configuration overview <PLFAdminGuide.Configuration.ConfigurationOverview>`.
 
 **Particularly in Tomcat**, you also need to edit
 ``conf/Catalina/localhost/context.xml.default`` file:
@@ -654,9 +468,7 @@ Configuring eXo Chat database
    recommended version for eXo Platform 5.0 is **3.4**.
 
 2. Configure the database parameters in ``chat.properties`` or
-   ``exo.properties``. The files are located in
-   ``$PLATFORM_TOMCAT_HOME/gatein/conf`` for Tomcat and
-   ``$PLATFORM_JBOSS_HOME/standalone/configuration/gatein`` for Jboss.
+   ``exo.properties``. The files are located in ``$PLATFORM_TOMCAT_HOME/gatein/conf``
 
 More details in :ref:`chat configuration <Configuration.ChatConfiguration>`
 section.
@@ -813,36 +625,4 @@ For more details, refer to the following:
 
 -  https://confluence.atlassian.com/display/JIRA/Surviving+Connection+Closures
 
-**Q:** **How to enable managed connection?**
-
-**A:** This question is specific to the JCR datasource in Platform JBoss
-package.
-
-When you want to use managed connections, set "true" for the
-``gatein.jcr.datasource.managed`` property in the
-``$PLATFORM_JBOSS_HOME/standalone/configuration/gatein/exo.properties``
-file. See :ref:`Configuration overview <Configuration.ConfigurationOverview>`
-if you have not created this file yet.
-
-.. code:: java
-
-    gatein.jcr.datasource.managed=true
-
-To be clear, this property needs to be "true" in two cases:
-
--  You use a **datasource** with JTA enabled:
-
-   .. code:: xml
-
-       <datasource jndi-name="java:/comp/env/exo-jcr_portal" jta="true" .../>
-
--  You use an **xa-datasource**:
-
-   .. code:: xml
-
-       <xa-datasource  jndi-name="java:/comp/env/exo-jcr_portal" .../>
-
-Using managed connections has pros and cons, so only do it if you know
-what you are doing. By default eXo Platform JBoss uses **datasource
-jta="false"**.
 

--- a/docs/eXo_Core.rst
+++ b/docs/eXo_Core.rst
@@ -533,7 +533,7 @@ sources:
    per-Application Server extensions of this login module in the
    **org.exoplatform.services.security.jaas** package, which can be used
    in appropriate AS. In particular, eXo has dedicated Login modules for
-   Tomcat, JBoss, JOnAS and WebSphere.
+   Tomcat, JOnAS and WebSphere.
 
 -  Besides that, in case when the third-party authentication mechanism
    is required,
@@ -563,7 +563,7 @@ To make it work in the particular J2EE server, it is necessary to add
 specific Principals/Credentials to the Subject to be propagated into the
 specific J2EE container implementation. The DefaultLoginModule is
 extended by overloading its commit() method with a dedicated logic,
-presently available for Tomcat, JBoss and JOnAS application servers.
+presently available for Tomcat and JOnAS application servers.
 
 Furthermore, you can use the optional RolesExtractor which is
 responsible for mapping primary Subject's principals (userId and a set
@@ -3419,55 +3419,6 @@ Specify a new login module for JAAS:
          org.exoplatform.services.security.j2ee.DigestAuthenticationTomcatLoginModule required;
        };
 
-**JBoss server configuration**
-
-Edit the configuration file located at
-``$PLATFORM_JBOSS_HOME/standalone/deployments/platform.ear/exo.portal.web.rest.war!/WEB-INF/web.xml``
-by replacing
-
-.. code:: xml
-
-    <login-config>
-        <auth-method>BASIC</auth-method>
-        <realm-name>gatein-domain</realm-name>
-    </login-config>
-
-with
-
-.. code:: xml
-
-    <login-config>
-        <auth-method>DIGEST</auth-method>
-        <realm-name>gatein-domain</realm-name>
-    </login-config>
-
-Edit the login configuration file located at
-``$PLATFORM_JBOSS_HOME/standalone/configuration/standalone-exo.xml``:
-
-.. code:: xml
-
-    <security-domain name="gatein-domain" cache-type="default">
-        <authentication>
-            <login-module code="org.exoplatform.services.security.j2ee.DigestAuthenticationJbossLoginModule" flag="required">
-                <module-option name="usersProperties" value="path/to/users.properties" />
-                <module-option name="rolesProperties" value="path/to/roles.properties" />
-                <module-option name="hashAlgorithm" value="MD5" />
-                <module-option name="hashEncoding" value="rfc2617" />
-                <module-option name="hashUserPassword" value="false" />
-                <module-option name="hashStorePassword" value="true" />
-                <module-option name="passwordIsA1Hash" value="true" />
-                <module-option name="storeDigestCallback" value="org.jboss.security.auth.spi.RFC2617Digest" />
-            </login-module>
-        </authentication>
-    </security-domain>
-
-You probably should define **users.properties** and **roles.properties**
-according to your own needs.
-
-See
-`here <https://docs.jboss.org/author/display/AS71/Security+Realms>`__
-for more information about the JBoss server Digest authentication
-configuration.
 
 **Organization Service implementation requirements**
 

--- a/docs/eXo_Kernel.rst
+++ b/docs/eXo_Kernel.rst
@@ -1376,11 +1376,6 @@ overloaded in the following lookup sequence:
 
    -  For Tomcat, the value of the variable *${catalina.home}*.
 
-   -  For JBoss AS, the value of the variable
-      *${jboss.server.config.url}* or *${jboss.server.config.dir}* if
-      the ``exo-conf`` directory can be found there; otherwise it will
-      be the value of the *${jboss.home.dir}* variable.
-
 -  *$PORTAL\_NAME* is the name of portal web application.
 
 -  External configuration location can be overridden with System
@@ -1424,7 +1419,7 @@ overloaded in the following lookup sequence:
     -  The ``.ear`` and ``.war`` files from which Kernel gets the
        configuration files for the RootContainer, are found thanks to a
        lookup inside the standard deployment folders, but so far those
-       folders are only properly defined in case of JBoss AS, Tomcat and
+       folders are only properly defined in case of Tomcat and
        Jetty. For other application servers, you will need to use the
        System property described in the previous note.
 
@@ -2454,15 +2449,12 @@ Profiles activation
 An active profile list is obtained during the boot of the root container
 and is composed of the system property *exo.profiles* - a
 comma-separated list - and a server specific profile value (Tomcat for
-Tomcat, JBoss for JBoss, and more).
+Tomcat).
 
 ::
 
     # runs GateIn on Tomcat with the profiles tomcat and foo
     sh gatein.sh -Dexo.profiles=foo
-
-    # runs GateIn on JBoss with the profiles jboss, foo and bar
-    sh run.sh -Dexo.profiles=foo,bar
 
 Profiles configuration
 ------------------------
@@ -4442,7 +4434,7 @@ context factory by a context factory that is ExoContainer aware and that
 is able to delegate to the original initial context factory if it
 detects that it is not in the eXo scope. By default, the feature is
 disabled since it is only required on AS that does not share the objects
-by default like Tomcat and it is not the case of JBoss AS.
+by default like Tomcat.
 
 The BindReferencePlugin component plugin configuration example (for JDBC
 datasource):
@@ -4531,7 +4523,7 @@ Configuration examples
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
 `Log4J <http://logging.apache.org/log4j/>`__ is a very popular and
-flexible logging system. It is a good option for JBoss.
+flexible logging system.
 
 .. code:: xml
 


### PR DESCRIPTION
* DOC-4356: Remove Jboss configurations on Installation chapter
* DOC-4356: Remove Jboss refs from Security chapter
* DOC-4356: Remove jboss refs from Management and database sections
* DOC-4356: Remove Jboss refs from Upgrade, Deployment and Clustering chapters
* DOC-4356: Remove Jboss refs from LDAP and configuration chapters
* DOC-4356: Remove Jboss refs from SSO, Application and backup chapters
* DOC-4356: Remove Jboss refs from Content, eXo-Addons and GetStarted chapters
* DOC-4356: Remove jboss refs in JCR and kernel chapters

(cherry picked from commit e70009cc67a772efe00c1fd54e64ade9607f78f2)