### PR TITLE
Security Fix : update quartz from 2.2.2 to 2.3.2.

### DIFF
--- a/docs/Configuration.rst
+++ b/docs/Configuration.rst
@@ -1415,7 +1415,7 @@ MongoDB configuration
 |                             | eXo Chat         |                             |
 |                             | server.          |                             |
 +-----------------------------+------------------+-----------------------------+
-| :ref:`chatCronNotifCleanup  | The frequency of | 0 0/60 \* \* \* ?           |
+| :ref:`chatCronNotifCleanup  | The frequency of | 0 0 \* \* \* ?           |
 | <ChatServerConf>`           | cleaning eXo     |                             |
 |                             | Chat             |                             |
 |                             | notifications.Th |                             |
@@ -5819,7 +5819,7 @@ Chat Server
 | ``chatPassPhrase``      | *chat*             | The password to access REST service  |
 |                         |                    | on the eXo Chat server.              |
 +-------------------------+--------------------+--------------------------------------+
-| ``chatCronNotifCleanup``| *0 0/60 \* \* \* ?*| The notifications are cleaned up     |
+| ``chatCronNotifCleanup``| *0 0 \* \* \* ?*| The notifications are cleaned up     |
 |                         |                    | every one hour by default. To learn  |
 |                         |                    | the syntax of Cron expression, see   |
 |                         |                    | :ref:`Scheduled synchronization,     |

--- a/docs/database_configuration.rst
+++ b/docs/database_configuration.rst
@@ -524,7 +524,7 @@ configuration is in the section *MongoDB*):
     chatServerBase=http://127.0.0.1:8080
     chatServerUrl=/chatServer
     chatPortalPage=/portal/intranet/chat
-    chatCronNotifCleanup=0 0/60 * * * ?
+    chatCronNotifCleanup=0 0 * * * ?
     teamAdminGroup=/platform/users
     chatReadTotalJson=200
 


### PR DESCRIPTION
Cron syntax 0/60 is no more valid
This fix change the documentation about this cron expression