### PR TITLE
Remove User Guide and Administrator Guide as it shipped in the platform

### DIFF
--- a/docs/GetStartedUserGuide.rst
+++ b/docs/GetStartedUserGuide.rst
@@ -1,0 +1,7 @@
+.. _user-admin-docs:
+
+################
+User and Administrator Guides
+################
+
+User and Functional Administrator guides are now directly shipped in the platform. You can find them in space “eXo Knowledge base”, open to administrators.

--- a/docs/GetStartedUserGuide.rst
+++ b/docs/GetStartedUserGuide.rst
@@ -4,4 +4,4 @@
 User and Administrator Guides
 ################
 
-User and Functional Administrator guides are now directly shipped in the platform. You can find them in space “eXo Knowledge base”, open to administrators.
+User and Functional Administrator guides are now directly shipped WITH the platform. You can find them in THE space “eXo Knowledge base”, open to administrators.

--- a/docs/GetStartedUserGuide.rst
+++ b/docs/GetStartedUserGuide.rst
@@ -4,4 +4,4 @@
 User and Administrator Guides
 ################
 
-User and Functional Administrator guides are now directly shipped WITH the platform. You can find them in THE space “eXo Knowledge base”, open to administrators.
+User and Functional Administrator guides are now directly shipped with the platform. You can find them in the space “eXo Knowledge base”, open to administrators.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -10,8 +10,7 @@ The main guides in eXo Platform documentation:
 
 * :ref:`whatsnew`
 * :ref:`GettingStarted`
-* :ref:`user-docs`
-* :ref:`admin-docs`
+* :ref:`user-admin-docs`
 * :ref:`developer-docs`
 * :ref:`addons-docs`
 * :ref:`mobile-docs`
@@ -35,51 +34,13 @@ The main guides in eXo Platform documentation:
    
    GettingStartedeXoCommunity   
    
-.. _user-docs:
+.. _user-admin-docs:
 
-.. toctree::
-   :maxdepth: 2
-   :caption: User Guide  
-   
-   introduction
-   GettingStarted
-   PersonalApplications
-   UserWallet
-   UsingPerkStore
-   UsingKudos
-   ManageTasks
-   Chat
-   webconferencing
-   Manage-Space
-   Wiki
-   Manage-Documents
-   Forum
-   Calendar
-   Manage-Sites
-   Search
-   Analytics
-   Administration
-   
-.. _admin-docs:   
+################
+User and Administrator Guide
+################
 
-.. toctree::
-   :maxdepth: 2
-   :caption: Administrator Guide
-   
-   Installation
-   eXo_addons
-   Configuration
-   database_configuration
-   Deployment
-   Management
-   Clustering
-   LDAP
-   OAuthIntegration
-   Backup
-   Upgrade
-   Security
-   Elasticsearch
-   Indexing
+User and Administrator guides are now directly shipped in the platform. You can find them in space "Knowledge base".
 
 .. _developer-docs:  
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -67,8 +67,7 @@ The main guides in eXo Platform documentation:
 .. toctree::
    :maxdepth: 2
    :caption: eXo Add-on Guide 
-   
-   LeckoAnalytics
+
    OnlyOffice
    SSO
    WCM

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -36,11 +36,11 @@ The main guides in eXo Platform documentation:
    
 .. _user-admin-docs:
 
-################
-User and Administrator Guide
-################
+.. toctree::
+   :maxdepth: 2
+   :caption: User and Administrator Guides
 
-User and Administrator guides are now directly shipped in the platform. You can find them in space "Knowledge base".
+   GetStartedUserGuide
 
 .. _developer-docs:  
 
@@ -108,9 +108,7 @@ User and Administrator guides are now directly shipped in the platform. You can 
    eXo_Kernel
    eXo_Core
    eXo_Web_Services
-   
-      
-   
+
 .. _reference-platform-docs:
 
 .. toctree::


### PR DESCRIPTION
User and Administrator guides are now present when starting eXo Platform, in the space Knowledge Base.
So we remove it from the documentation site.